### PR TITLE
Added ntp and upgraded boost version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN \
       libncurses-dev \
       doxygen \
       ca-certificates \
+      ntp \
+      wget \
     && \
     apt-get update -y && \
     apt-get install -y fish && \
@@ -36,10 +38,18 @@ RUN \
 	done && \
       git submodule sync --recursive ) && \
     git submodule update --init --recursive && \
+    BOOST_ROOT=$HOME/opt/boost_1_60_0 && \
+    wget -c 'http://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.tar.gz/download' -O boost_1_60_0.tar.gz &&\
+    tar -zxvf boost_1_60_0.tar.gz && \
+    cd boost_1_60_0/ && \
+    ./bootstrap.sh "--prefix=$BOOST_ROOT" && \
+    ./b2 install -j$(nproc) && \
+    cd .. && \
     cmake \
+        -DBOOST_ROOT="$BOOST_ROOT" \
         -DCMAKE_BUILD_TYPE=Release \
         . && \
-    make witness_node cli_wallet && \
+    make witness_node cli_wallet -j$(nproc) && \
     install -s programs/witness_node/witness_node programs/cli_wallet/cli_wallet /usr/local/bin && \
     #
     # Obtain version


### PR DESCRIPTION
This updates boost from 1.57.0 to 1.60.0 and also adds ntp to the docker build process.