### PR TITLE
GRPH-4-CliWalletCoreDumpOnCtrlD1604 - CLI Crash fix for 16.04

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -226,7 +226,7 @@ namespace detail {
 
       void new_connection( const fc::http::websocket_connection_ptr& c )
       {
-         auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(*c);
+         auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(c);
          auto login = std::make_shared<graphene::app::login_api>( std::ref(*_self) );
          login->enable_api("database_api");
 

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -65,7 +65,7 @@ void delayed_node_plugin::plugin_set_program_options(bpo::options_description& c
 
 void delayed_node_plugin::connect()
 {
-   my->client_connection = std::make_shared<fc::rpc::websocket_api_connection>(*my->client.connect(my->remote_endpoint));
+   my->client_connection = std::make_shared<fc::rpc::websocket_api_connection>(my->client.connect(my->remote_endpoint));
    my->database_api = my->client_connection->get_remote_api<graphene::app::database_api>(0);
    my->client_connection_closed = my->client_connection->closed.connect([this] {
       connection_failed();

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -171,7 +171,7 @@ int main( int argc, char** argv )
       fc::http::websocket_client client;
       idump((wdata.ws_server));
       auto con  = client.connect( wdata.ws_server );
-      auto apic = std::make_shared<fc::rpc::websocket_api_connection>(*con);
+      auto apic = std::make_shared<fc::rpc::websocket_api_connection>(con);
 
       auto remote_api = apic->get_remote_api< login_api >(1);
       edump((wdata.ws_user)(wdata.ws_password) );
@@ -211,7 +211,7 @@ int main( int argc, char** argv )
          _websocket_server->on_connection([&]( const fc::http::websocket_connection_ptr& c ){
             std::cout << "here... \n";
             wlog("." );
-            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(*c);
+            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(c);
             wsc->register_api(wapi);
             c->set_session_data( wsc );
          });
@@ -228,7 +228,7 @@ int main( int argc, char** argv )
       if( options.count("rpc-tls-endpoint") )
       {
          _websocket_tls_server->on_connection([&]( const fc::http::websocket_connection_ptr& c ){
-            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(*c);
+            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(c);
             wsc->register_api(wapi);
             c->set_session_data( wsc );
          });


### PR DESCRIPTION
CLI Crash on CTRL-D fix for Xenila/16.04 branch.

Similar PR raised for 18.04 branch as well.