### PR TITLE
GRPH-83 Performance Upgrade - Missed Blockcount

### DIFF
--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -50,9 +50,9 @@ void database::update_global_dynamic_data( const signed_block& b, const uint32_t
 
    // dynamic global properties updating
    modify( _dgp, [&b,this,missed_blocks]( dynamic_global_property_object& dgp ){
-      secret_hash_type::encoder enc;       
-      fc::raw::pack( enc, dgp.random );       
-      fc::raw::pack( enc, b.previous_secret );        
+      secret_hash_type::encoder enc;
+      fc::raw::pack( enc, dgp.random );
+      fc::raw::pack( enc, b.previous_secret );
       dgp.random = enc.result();
 
       _random_number_generator = fc::hash_ctr_rng<secret_hash_type, 20>(dgp.random.data());

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -263,7 +263,6 @@ namespace graphene { namespace chain {
          vector<witness_id_type> get_near_witness_schedule()const;
          void update_witness_schedule();
          void update_witness_schedule(const signed_block& next_block);
-         uint32_t update_witness_missed_blocks( const signed_block& b );
       
          void check_lottery_end_by_participants( asset_id_type asset_id );
          void check_ending_lotteries();

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -263,6 +263,7 @@ namespace graphene { namespace chain {
          vector<witness_id_type> get_near_witness_schedule()const;
          void update_witness_schedule();
          void update_witness_schedule(const signed_block& next_block);
+         uint32_t update_witness_missed_blocks( const signed_block& b );
       
          void check_lottery_end_by_participants( asset_id_type asset_id );
          void check_ending_lotteries();


### PR DESCRIPTION
PR includes following fixes for below issues:

1) database::update_global_dynamic_data iterates through all missed blocks, increasing the missed block count of each witness. This is inefficient if the number of missed blocks is large. In normal operation it is not a problem, but it slows down the unit tests that skip large numbers of blocks to simulate hardforks.

2) the previous algorithm would skip missed blocks for the witness who signed the first block after the gap.

Note: A chain halt is not any witness's fault so when missed_blocks >= witnesses.size, don't count misses for anyone.

Testcase:
./tests/chain_test -t block_tests/miss_some_blocks
./tests/chain_test -t block_tests/miss_many_blocks