### PR TITLE
[GRPH-86] fix duplicate ops returned in get_account_history

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3449,30 +3449,54 @@ asset wallet_api::get_lottery_balance( asset_id_type lottery_id )const
    return my->_remote_db->get_lottery_balance( lottery_id );
 }
 
-vector<operation_detail> wallet_api::get_account_history(string name, int limit)const
+vector<operation_detail> wallet_api::get_account_history(string name, int limit) const
 {
    vector<operation_detail> result;
    auto account_id = get_account(name).get_id();
 
-   while( limit > 0 )
+   while (limit > 0)
    {
+      bool skip_first_row = false;
       operation_history_id_type start;
-      if( result.size() )
+      if (result.size())
       {
          start = result.back().op.id;
-         start = start + 1;
+         if (start == operation_history_id_type()) // no more data
+            break;
+         start = start + (-1);
+         if (start == operation_history_id_type()) // will return most recent history if directly call remote API with this
+         {
+            start = start + 1;
+            skip_first_row = true;
+         }
       }
 
+      int page_limit = skip_first_row ? std::min(100, limit + 1) : std::min(100, limit);
 
-      vector<operation_history_object> current = my->_remote_hist->get_account_history(account_id, operation_history_id_type(), std::min(100,limit), start);
-      for( auto& o : current ) {
+      vector<operation_history_object> current = my->_remote_hist->get_account_history(account_id, operation_history_id_type(),
+                                                                                       page_limit, start);
+      bool first_row = true;
+      for (auto &o : current)
+      {
+         if (first_row)
+         {
+            first_row = false;
+            if (skip_first_row)
+            {
+               continue;
+            }
+         }
          std::stringstream ss;
          auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
-         result.push_back( operation_detail{ memo, ss.str(), o } );
+         result.push_back(operation_detail{memo, ss.str(), o});
       }
-      if( (int)current.size() < std::min(100,limit) )
+
+      if (int(current.size()) < page_limit)
          break;
+
       limit -= current.size();
+      if (skip_first_row)
+         ++limit;
    }
 
    return result;

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -442,7 +442,7 @@ BOOST_FIXTURE_TEST_CASE( cli_vote_for_2_witnesses, cli_fixture )
 }
 
 ///////////////////////
-// Check account history pagination (see peerplay-core/issue/1176)
+// Check account history pagination
 ///////////////////////
 BOOST_FIXTURE_TEST_CASE( account_history_pagination, cli_fixture )
 {

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -27,6 +27,7 @@
 
 #include <graphene/utilities/tempdir.hpp>
 #include <graphene/bookie/bookie_plugin.hpp>
+#include <graphene/account_history/account_history_plugin.hpp>
 #include <graphene/egenesis/egenesis.hpp>
 #include <graphene/wallet/wallet.hpp>
 
@@ -117,6 +118,7 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
    std::shared_ptr<graphene::app::application> app1(new graphene::app::application{});
 
    app1->register_plugin< graphene::bookie::bookie_plugin>();
+   app1->register_plugin<graphene::account_history::account_history_plugin>();
    app1->startup_plugins();
    boost::program_options::variables_map cfg;
 #ifdef _WIN32


### PR DESCRIPTION
## Bug Description
Call the cli_wallet api with the params:
```{"id":"5665571840","jsonrpc":"2.0","method":"get_account_history","params":["alanguanwz9",1000]}```
The return result contains duplicate id : 1.11.323175501, 1.11.320758270

## To Run Test:
`./tests/cli_test -t account_history_pagination`