### PR TITLE
GRPH-90 Fix for history ID mismatch issue

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -600,10 +600,15 @@ namespace graphene { namespace app {
 
              if(node->operation_id(db).op.which() == operation_id)
                result.push_back( node->operation_id(db) );
-             }
+          }
           if( node->next == account_transaction_history_id_type() )
              node = nullptr;
           else node = &node->next(db);
+       }
+       if( stop.instance.value == 0 && result.size() < limit ) {
+          auto head = db.find(account_transaction_history_id_type());
+          if (head != nullptr && head->account == account && head->operation_id(db).op.which() == operation_id)
+            result.push_back(head->operation_id(db));
        }
        return result;
     }

--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -81,11 +81,23 @@ void account_history_plugin_impl::update_account_histories( const signed_block& 
 {
    graphene::chain::database& db = database();
    vector<optional< operation_history_object > >& hist = db.get_applied_operations();
+   bool is_first = true;
+   auto skip_oho_id = [&is_first,&db,this]() {
+      if( is_first && db._undo_db.enabled() ) // this ensures that the current id is rolled back on undo
+      {
+         db.remove( db.create<operation_history_object>( []( operation_history_object& obj) {} ) );
+         is_first = false;
+      }
+      else
+         _oho_index->use_next_id();
+   };
+
    for( optional< operation_history_object >& o_op : hist )
    {
       optional<operation_history_object> oho;
 
       auto create_oho = [&]() {
+         is_first = false;
          operation_history_object result = db.create<operation_history_object>( [&]( operation_history_object& h )
          {
             if( o_op.valid() )
@@ -99,7 +111,7 @@ void account_history_plugin_impl::update_account_histories( const signed_block& 
       {
          // Note: the 2nd and 3rd checks above are for better performance, when the db is not clean,
          //       they will break consistency of account_stats.total_ops and removed_ops and most_recent_op
-         _oho_index->use_next_id();
+         skip_oho_id();
          continue;
       }
       else if( !_partial_operations )
@@ -179,7 +191,7 @@ void account_history_plugin_impl::update_account_histories( const signed_block& 
          }
       }
       if (_partial_operations && ! oho.valid())
-         _oho_index->use_next_id();
+         skip_oho_id();
    }
 }
 

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -109,6 +109,24 @@ database_fixture::database_fixture()
    genesis_state.initial_parameters.current_fees->zero_all_fees();
    open_database();
 
+   // add account tracking for ahplugin for special test case with track-account enabled
+   if( !options.count("track-account") && boost::unit_test::framework::current_test_case().p_name.value == "track_account") {
+      std::vector<std::string> track_account;
+      std::string track = "\"1.2.18\"";
+      track_account.push_back(track);
+      options.insert(std::make_pair("track-account", boost::program_options::variable_value(track_account, false)));
+      options.insert(std::make_pair("partial-operations", boost::program_options::variable_value(true, false)));
+   }
+   // account tracking 2 accounts
+   if( !options.count("track-account") && boost::unit_test::framework::current_test_case().p_name.value == "track_account2") {
+      std::vector<std::string> track_account;
+      std::string track = "\"1.2.0\"";
+      track_account.push_back(track);
+      track = "\"1.2.17\"";
+      track_account.push_back(track);
+      options.insert(std::make_pair("track-account", boost::program_options::variable_value(track_account, false)));
+   }
+
    // app.initialize();
    ahplugin->plugin_set_app(&app);
    ahplugin->plugin_initialize(options);

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -407,4 +407,188 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
    } FC_LOG_AND_RETHROW()
 }
 
+BOOST_AUTO_TEST_CASE(track_account) {
+   try {
+      graphene::app::history_api hist_api(app);
+
+      // account_id_type() is not tracked
+
+      // account_id_type() creates alice(not tracked account)
+      const account_object& alice = create_account("alice");
+      auto alice_id = alice.id;
+
+      //account_id_type() creates some ops
+      create_bitasset("CNY", account_id_type());
+      create_bitasset("USD", account_id_type());
+
+      // account_id_type() creates dan(account tracked)
+      const account_object& dan = create_account("dan");
+      auto dan_id = dan.id;
+
+      // dan makes 1 op
+      create_bitasset("EUR", dan_id);
+
+      generate_block( ~database::skip_fork_db );
+
+      // anything against account_id_type() should be {}
+      vector<operation_history_object> histories = 
+      hist_api.get_account_history(account_id_type(), operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 1, operation_history_id_type(2));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      // anything against alice should be {}
+      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+      histories = hist_api.get_account_history(alice_id, operation_history_id_type(1), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+      histories = hist_api.get_account_history(alice_id, operation_history_id_type(1), 1, operation_history_id_type(2));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      // dan should have history
+      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+
+      // create more ops, starting with an untracked account
+      create_bitasset( "BTC", account_id_type() );
+      create_bitasset( "GBP", dan_id );
+
+      generate_block( ~database::skip_fork_db );
+
+      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3u);
+
+      db.pop_block();
+
+      // Try again, should result in same object IDs
+      create_bitasset( "BTC", account_id_type() );
+      create_bitasset( "GBP", dan_id );
+
+      generate_block();
+
+      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3u);
+   } catch (fc::exception &e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
+BOOST_AUTO_TEST_CASE(track_account2) {
+   try {
+      graphene::app::history_api hist_api(app);
+
+      // account_id_type() is tracked
+
+      // account_id_type() creates alice(tracked account)
+      const account_object& alice = create_account("alice");
+      auto alice_id = alice.id;
+
+      //account_id_type() creates some ops
+      create_bitasset("CNY", account_id_type());
+      create_bitasset("USD", account_id_type());
+
+      // alice makes 1 op
+      create_bitasset("EUR", alice_id);
+
+      // account_id_type() creates dan(account not tracked)
+      const account_object& dan = create_account("dan");
+      auto dan_id = dan.id;
+
+      generate_block();
+
+      // all account_id_type() should have 4 ops {4,2,1,0}
+      vector<operation_history_object> histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
+
+      // all alice account should have 2 ops {3, 0}
+      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0u);
+
+      // alice first op should be {0}
+      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 1, operation_history_id_type(1));
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+
+      // alice second op should be {3}
+      histories = hist_api.get_account_history(alice_id, operation_history_id_type(1), 1, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+
+      // anything against dan should be {}
+      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+      histories = hist_api.get_account_history(dan_id, operation_history_id_type(1), 10, operation_history_id_type(0));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+      histories = hist_api.get_account_history(dan_id, operation_history_id_type(1), 1, operation_history_id_type(2));
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+   } catch (fc::exception &e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
+BOOST_AUTO_TEST_CASE(get_account_history_operations) {
+   try {
+      graphene::app::history_api hist_api(app);
+
+      //account_id_type() do 3 ops
+      create_bitasset("CNY", account_id_type());
+      create_account("sam");
+      create_account("alice");
+
+      generate_block();
+      fc::usleep(fc::milliseconds(2000));
+
+      int asset_create_op_id = operation::tag<asset_create_operation>::value;
+      int account_create_op_id = operation::tag<account_create_operation>::value;
+
+      //account_id_type() did 1 asset_create op
+      vector<operation_history_object> histories = hist_api.get_account_history_operations(account_id_type(), asset_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+      BOOST_CHECK_EQUAL(histories[0].op.which(), asset_create_op_id);
+
+      //account_id_type() did 2 account_create ops
+      histories = hist_api.get_account_history_operations(account_id_type(), account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
+
+      // No asset_create op larger than id1
+      histories = hist_api.get_account_history_operations(account_id_type(), asset_create_op_id, operation_history_id_type(), operation_history_id_type(1), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      // Limit 1 returns 1 result
+      histories = hist_api.get_account_history_operations(account_id_type(), account_create_op_id, operation_history_id_type(),operation_history_id_type(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
+
+      // alice has 1 op
+      histories = hist_api.get_account_history_operations(get_account("alice").id, account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
+
+   } catch (fc::exception &e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
A node with track-account configured has bigger history_object_id's (1.11.x) than nodes with default configuration values.

The problem was caused by using of use_next_id(). 

When creating new objects, old_index_next_ids will be updated in on_create(), when undoing, the value will be reverted to saved old id.

But in history plugin we didn't save old ids in old_index_next_ids, thus no reversion will be done when undoing.

Bitshares PR: https://github.com/bitshares/bitshares-core/pull/875