### PR TITLE
[GRPH-111] Added get_asset_count API

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -103,6 +103,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<optional<asset_object>> get_assets(const vector<asset_id_type>& asset_ids)const;
       vector<asset_object>           list_assets(const string& lower_bound_symbol, uint32_t limit)const;
       vector<optional<asset_object>> lookup_asset_symbols(const vector<string>& symbols_or_ids)const;
+      uint64_t                       get_asset_count()const;
 
       // Peerplays
       vector<sport_object>                list_sports() const; 
@@ -1022,6 +1023,15 @@ vector<optional<asset_object>> database_api_impl::lookup_asset_symbols(const vec
    return result;
 }
 
+uint64_t database_api::get_asset_count()const
+{
+   return my->get_asset_count();
+}
+
+uint64_t database_api_impl::get_asset_count()const
+{
+   return _db.get_index_type<asset_index>().indices().size();
+}
 ////////////////////
 // Lottery Assets //
 ////////////////////

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -342,6 +342,12 @@ class database_api
        * This function has semantics identical to @ref get_objects
        */
       vector<optional<asset_object>> lookup_asset_symbols(const vector<string>& symbols_or_ids)const;
+
+      /**
+       * @brief Get assets count
+       * @return The assets count
+       */
+      uint64_t get_asset_count()const;
    
       ////////////////////
       // Lottery Assets //
@@ -727,6 +733,7 @@ FC_API(graphene::app::database_api,
    (get_assets)
    (list_assets)
    (lookup_asset_symbols)
+   (get_asset_count)
 
    // Peerplays
    (list_sports)

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -348,6 +348,12 @@ class wallet_api
        * @returns the list of asset objects, ordered by symbol
        */
       vector<asset_object>              list_assets(const string& lowerbound, uint32_t limit)const;
+
+      /** Returns assets count registered on the blockchain.
+       * 
+       * @returns assets count
+       */
+      uint64_t get_asset_count()const;
    
    
       vector<asset_object>              get_lotteries( asset_id_type stop = asset_id_type(),
@@ -1925,6 +1931,7 @@ FC_API( graphene::wallet::wallet_api,
         (list_accounts)
         (list_account_balances)
         (list_assets)
+        (get_asset_count)
         (import_key)
         (import_accounts)
         (import_account_keys)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3429,6 +3429,11 @@ vector<asset_object> wallet_api::list_assets(const string& lowerbound, uint32_t 
    return my->_remote_db->list_assets( lowerbound, limit );
 }
 
+uint64_t wallet_api::get_asset_count()const
+{
+   return my->_remote_db->get_asset_count();
+}
+
 vector<asset_object> wallet_api::get_lotteries( asset_id_type stop,
                                                 unsigned limit,
                                                 asset_id_type start )const


### PR DESCRIPTION
An API call that can return the total number of assets available. This will be used to get rid of loading assets on UI