### PR TITLE
[GRPH-95] Enhancement for session undo storage

### DIFF
--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -345,6 +345,8 @@ processed_transaction database::push_proposal(const proposal_object& proposal)
    size_t old_applied_ops_size = _applied_ops.size();
 
    try {
+      if( _undo_db.size() >= _undo_db.max_size() )
+         _undo_db.set_max_size( _undo_db.size() + 1 );
       auto session = _undo_db.start_undo_session(true);
       for( auto& op : proposal.proposed_transaction.operations )
          eval_state.operation_results.emplace_back(apply_operation(eval_state, op));

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -336,6 +336,8 @@ processed_transaction database::validate_transaction( const signed_transaction& 
 
 processed_transaction database::push_proposal(const proposal_object& proposal)
 { try {
+   FC_ASSERT( _undo_db.size() < _undo_db.max_size(), "Undo database is full!" );
+
    transaction_evaluation_state eval_state(this);
    eval_state._is_proposed_trx = true;
 
@@ -345,8 +347,6 @@ processed_transaction database::push_proposal(const proposal_object& proposal)
    size_t old_applied_ops_size = _applied_ops.size();
 
    try {
-      if( _undo_db.size() >= _undo_db.max_size() )
-         _undo_db.set_max_size( _undo_db.size() + 1 );
       auto session = _undo_db.start_undo_session(true);
       for( auto& op : proposal.proposed_transaction.operations )
          eval_state.operation_results.emplace_back(apply_operation(eval_state, op));
@@ -673,6 +673,19 @@ processed_transaction database::apply_transaction(const signed_transaction& trx,
    return result;
 }
 
+class undo_size_restorer {
+   public:
+      undo_size_restorer( undo_database& db ) : _db( db ), old_max( db.max_size() ) {
+         _db.set_max_size( old_max * 2 );
+      }
+      ~undo_size_restorer() {
+         _db.set_max_size( old_max );
+      }
+   private:
+      undo_database& _db;
+      size_t         old_max;
+};
+
 processed_transaction database::_apply_transaction(const signed_transaction& trx)
 { try {
    uint32_t skip = get_node_properties().skip_flags;
@@ -731,6 +744,7 @@ processed_transaction database::_apply_transaction(const signed_transaction& trx
 
    eval_state.operation_results.reserve(trx.operations.size());
 
+   const undo_size_restorer undo_guard( _undo_db );
    //Finally process the operations
    processed_transaction ptrx(trx);
    _current_op_in_trx = 0;


### PR DESCRIPTION
Backport BitShares PR https://github.com/bitshares/bitshares-core/pull/1247

This enhancement increases temporally undo db size for nested proposals if it is needed,  and than returns it back.

QA notes: to test this code you need to create the nested proposal with big enough nested authorities  required to sign this proposal ([see details here](https://dev.bitshares.works/en/master/knowledge_base/trn_proposed_transactions.html))