### PR TITLE
Use random port numbers in app_test

### DIFF
--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -58,28 +58,35 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       graphene::app::application app1;
       app1.register_plugin<graphene::account_history::account_history_plugin>();
       boost::program_options::variables_map cfg;
-      cfg.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:3939"), false));
+      cfg.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:0"), false));
       app1.initialize(app_dir.path(), cfg);
+      cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+
+      BOOST_TEST_MESSAGE( "Starting app1 and waiting 1500 ms" );
+      app1.startup();
+      fc::usleep(fc::milliseconds(500));
+      string endpoint1 = app1.p2p_node()->get_actual_listening_endpoint();
 
       BOOST_TEST_MESSAGE( "Creating and initializing app2" );
+      auto cfg2 = cfg;
 
       graphene::app::application app2;
       app2.register_plugin<account_history::account_history_plugin>();
-      auto cfg2 = cfg;
       cfg2.erase("p2p-endpoint");
-      cfg2.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:4040"), false));
-      cfg2.emplace("seed-node", boost::program_options::variable_value(vector<string>{"127.0.0.1:3939"}, false));
+      cfg2.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:0"), false));
+      cfg2.emplace("seed-node", boost::program_options::variable_value(vector<string>{endpoint1}, false));
       app2.initialize(app2_dir.path(), cfg2);
-
-      cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
       cfg2.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app2_dir), false));
 
-      BOOST_TEST_MESSAGE( "Starting app1 and waiting 1500 ms" );
-      app1.startup();                                      
-      fc::usleep(fc::milliseconds(1500));
       BOOST_TEST_MESSAGE( "Starting app2 and waiting 1500 ms" );
       app2.startup();
-      fc::usleep(fc::milliseconds(1500));
+      int counter = 0;
+      while(!app2.p2p_node()->is_connected())
+      {
+          fc::usleep(fc::milliseconds(500));
+          if(counter++ >= 100)
+              break;
+      }
 
       BOOST_REQUIRE_EQUAL(app1.p2p_node()->get_connection_count(), 1);
       BOOST_CHECK_EQUAL(std::string(app1.p2p_node()->get_connected_peers().front().host.get_address()), "127.0.0.1");


### PR DESCRIPTION
Address issue https://github.com/peerplays-network/peerplays/issues/152

Looks like listening socket is closed in correct way and it is the OS issues,  so the best way I've found is to use random free port in tests.

QA notes: to check the fix is working start `tests/app_test` several times one after other.