### PR TITLE
GRPH-79 Proposal Information Bug Fix

### DIFF
--- a/libraries/chain/include/graphene/chain/proposal_object.hpp
+++ b/libraries/chain/include/graphene/chain/proposal_object.hpp
@@ -96,4 +96,4 @@ typedef generic_index<proposal_object, proposal_multi_index_container> proposal_
 FC_REFLECT_DERIVED( graphene::chain::proposal_object, (graphene::chain::object),
                     (expiration_time)(review_period_time)(proposed_transaction)(required_active_approvals)
                     (available_active_approvals)(required_owner_approvals)(available_owner_approvals)
-                    (available_key_approvals)(proposer) )
+                    (available_key_approvals)(proposer)(fail_reason))


### PR DESCRIPTION
The `fail_reason` was missing from `FC_REFLECT_DERIVED` for `proposal_object` class. Hence it wasn't returning while calling `get_object obj_id`