### PR TITLE
BLOCKBACK- 174 Roll in GPOS votes from 6th sub-period 

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -787,7 +787,7 @@ double database::calculate_vesting_factor(const account_object& stake_account)
    if(current_subperiod == 1 && this->head_block_time() >= HARDFORK_GPOS_TIME + vesting_period)   //Applicable only from 2nd vesting period
    {
       if(last_date_voted > period_start - vesting_subperiod)
-         return 1;   //return vesting factor as 1
+         return 1;
    }
 
    if(last_date_voted < period_start) return 0;

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -780,6 +780,16 @@ double database::calculate_vesting_factor(const account_object& stake_account)
    uint32_t current_subperiod = get_gpos_current_subperiod();
  
    if(current_subperiod == 0 || current_subperiod > number_of_subperiods) return 0;
+
+   // On starting new vesting period, all votes become zero until some one votes, To avoid a situation of zero votes, 
+   // changes done to roll in GPOS rules, the vesting factor will be 1 for who ever votes in 6th sub-period of last vesting period
+   // BLOCKBACK-174 fix
+   if(current_subperiod == 1 && this->head_block_time() >= HARDFORK_GPOS_TIME + vesting_period)   //Applicable only from 2nd vesting period
+   {
+      if(last_date_voted > period_start - vesting_subperiod)
+         return 1;   //return vesting factor as 1
+   }
+
    if(last_date_voted < period_start) return 0;
 
    double numerator = number_of_subperiods;

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -781,8 +781,8 @@ double database::calculate_vesting_factor(const account_object& stake_account)
  
    if(current_subperiod == 0 || current_subperiod > number_of_subperiods) return 0;
 
-   // On starting new vesting period, all votes become zero until some one votes, To avoid a situation of zero votes, 
-   // changes done to roll in GPOS rules, the vesting factor will be 1 for who ever votes in 6th sub-period of last vesting period
+   // On starting new vesting period, all votes become zero until someone votes, To avoid a situation of zero votes, 
+   // changes were done to roll in GPOS rules, the vesting factor will be 1 for whoever votes in 6th sub-period of last vesting period
    // BLOCKBACK-174 fix
    if(current_subperiod == 1 && this->head_block_time() >= HARDFORK_GPOS_TIME + vesting_period)   //Applicable only from 2nd vesting period
    {

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2193,9 +2193,6 @@ public:
             FC_THROW("Account ${account} was already voting for witness ${witness} in the current GPOS sub-period", ("account", voting_account)("witness", witness));
          else
             update_vote_time = true;   //Allow user to vote in each sub-period(Update voting time, which is reference in calculating VF)
-
-         if (!insert_result.second)
-            FC_THROW("Account ${account} has already voted for witness ${witness}", ("account", voting_account)("witness", witness));
       }
       else
       {

--- a/tests/tests/gpos_tests.cpp
+++ b/tests/tests/gpos_tests.cpp
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE( voting )
       auto witness2 = witness_id_type(2)(db);
       BOOST_CHECK_EQUAL(witness2.total_votes, 0);
 
-      // vote for witness1
+      // vote for witness1 and witness2 - sub-period 1
       vote_for(alice_id, witness1.vote_id, alice_private_key);
       vote_for(bob_id, witness2.vote_id, bob_private_key);
 
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE( voting )
 
       advance_x_maint(10);
 
-      //vote bob tot witness2 in each subperiod and verify votes
+      //Bob votes for witness2 - sub-period 2
       vote_for(bob_id, witness2.vote_id, bob_private_key);
       // go to maint
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
@@ -595,6 +595,7 @@ BOOST_AUTO_TEST_CASE( voting )
       BOOST_CHECK_EQUAL(witness2.total_votes, 100);
       
       advance_x_maint(10);
+      //Bob votes for witness2 - sub-period 3
       vote_for(bob_id, witness2.vote_id, bob_private_key);
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       // decay more
@@ -605,7 +606,7 @@ BOOST_AUTO_TEST_CASE( voting )
 
       advance_x_maint(10);
       
-      // more
+      // Bob votes for witness2 - sub-period 4
       vote_for(bob_id, witness2.vote_id, bob_private_key);
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       // decay more
@@ -616,7 +617,7 @@ BOOST_AUTO_TEST_CASE( voting )
 
       advance_x_maint(10);
       
-      // more
+      // Bob votes for witness2 - sub-period 5
       vote_for(bob_id, witness2.vote_id, bob_private_key);
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       // decay more
@@ -628,7 +629,7 @@ BOOST_AUTO_TEST_CASE( voting )
 
       advance_x_maint(10);
       
-      // more
+      // Bob votes for witness2 - sub-period 6
       vote_for(bob_id, witness2.vote_id, bob_private_key);
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       // decay more
@@ -641,7 +642,7 @@ BOOST_AUTO_TEST_CASE( voting )
       BOOST_CHECK_EQUAL(db.get_global_properties().parameters.gpos_period_start(), now.sec_since_epoch());
 
       advance_x_maint(5);
-      // a new GPOS period is in but vote from user is before the start. WHo ever votes in 6th sub-period, votes will carry
+      // a new GPOS period is in but vote from user is before the start. Whoever votes in 6th sub-period, votes will carry
       now = db.head_block_time();
       BOOST_CHECK_EQUAL(db.get_global_properties().parameters.gpos_period_start(), now.sec_since_epoch());
 


### PR DESCRIPTION
On starting new vesting period, all votes become zero until someone votes, To avoid a situation of zero votes, changes done to roll in GPOS rules. The vesting factor will be 1 for whoever votes in 6th sub-period of last vesting period