### PR TITLE
[SON-142] Fix failed SON deletion CLI tests

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/son.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/son.hpp
@@ -58,4 +58,4 @@ FC_REFLECT(graphene::chain::son_update_operation, (fee)(son_id)(owner_account)(n
            (new_signing_key)(new_pay_vb) )
 
 FC_REFLECT(graphene::chain::son_delete_operation::fee_parameters_type, (fee) )
-FC_REFLECT(graphene::chain::son_delete_operation, (fee)(son_id)(owner_account) )
+FC_REFLECT(graphene::chain::son_delete_operation, (fee)(son_id)(payer)(owner_account) )


### PR DESCRIPTION
The reason was incorrect `son_delete_operation` reflection: new field `payer` wasn't added to reflection scheme,  and it was the reason of the incorrect serialization.