### PR TITLE
[SON-160] Fix create_vesting wallet_api call

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1429,14 +1429,16 @@ class wallet_api
 
       /** Creates a vesting deposit owned by the given account.
        *
-       * @param owner_account the name or id of the account
-       * @param amount the amount to deposit
+       * @param owner_account vesting balance owner and creator (the name or id)
+       * @param amount amount to vest
+       * @param asset_symbol the symbol of the asset to vest
        * @param vesting_type "normal", "gpos" or "son"
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction registering a vesting object
        */
-      signed_transaction create_vesting(string owner_account,
+      signed_transaction create_vesting_balance(string owner_account,
                                         string amount,
+                                        string asset_symbol,
                                         string vesting_type,
                                         bool broadcast = false);
 
@@ -2118,7 +2120,7 @@ FC_API( graphene::wallet::wallet_api,
         (update_witness)
         (create_worker)
         (update_worker_votes)
-        (create_vesting)
+        (create_vesting_balance)
         (get_vesting_balances)
         (withdraw_vesting)
         (vote_for_committee_member)

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1439,7 +1439,7 @@ class wallet_api
       signed_transaction create_vesting_balance(string owner_account,
                                         string amount,
                                         string asset_symbol,
-                                        string vesting_type,
+                                        vesting_balance_type vesting_type,
                                         bool broadcast = false);
 
       /**

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2107,17 +2107,20 @@ public:
       return sign_transaction( tx, broadcast );
    }
 
-   signed_transaction create_vesting(string owner_account,
+   signed_transaction create_vesting_balance(string owner_account,
                                      string amount,
+                                     string asset_symbol,
                                      string vesting_type,
                                      bool broadcast /* = false */)
    { try {
       account_object son_account = get_account(owner_account);
+      fc::optional<asset_object> asset_obj = get_asset(asset_symbol);
+      FC_ASSERT(asset_obj, "Invalid asset symbol {asst}", ("asst", asset_symbol));
 
       vesting_balance_create_operation op;
       op.creator = son_account.get_id();
       op.owner = son_account.get_id();
-      op.amount = asset_object().amount_from_string(amount);
+      op.amount = asset_obj->amount_from_string(amount);
       if (vesting_type == "normal")
           op.balance_type = vesting_balance_type::normal;
       else if (vesting_type == "gpos")
@@ -4271,12 +4274,13 @@ committee_member_object wallet_api::get_committee_member(string owner_account)
    return my->get_committee_member(owner_account);
 }
 
-signed_transaction wallet_api::create_vesting(string owner_account,
+signed_transaction wallet_api::create_vesting_balance(string owner_account,
                                               string amount,
+                                              string asset_symbol,
                                               string vesting_type,
                                               bool broadcast /* = false */)
 {
-   return my->create_vesting(owner_account, amount, vesting_type, broadcast);
+   return my->create_vesting_balance(owner_account, amount, asset_symbol, vesting_type, broadcast);
 }
 
 signed_transaction wallet_api::create_son(string owner_account,

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2110,7 +2110,7 @@ public:
    signed_transaction create_vesting_balance(string owner_account,
                                      string amount,
                                      string asset_symbol,
-                                     string vesting_type,
+                                     vesting_balance_type vesting_type,
                                      bool broadcast /* = false */)
    { try {
       account_object son_account = get_account(owner_account);
@@ -2121,16 +2121,7 @@ public:
       op.creator = son_account.get_id();
       op.owner = son_account.get_id();
       op.amount = asset_obj->amount_from_string(amount);
-      if (vesting_type == "normal")
-          op.balance_type = vesting_balance_type::normal;
-      else if (vesting_type == "gpos")
-          op.balance_type = vesting_balance_type::gpos;
-      else if (vesting_type == "son")
-          op.balance_type = vesting_balance_type::son;
-      else
-      {
-          FC_ASSERT( false, "unknown vesting type value ${vt}", ("vt", vesting_type) );
-      }
+      op.balance_type = vesting_type;
       if (op.balance_type == vesting_balance_type::son)
           op.policy = dormant_vesting_policy_initializer {};
 
@@ -4277,7 +4268,7 @@ committee_member_object wallet_api::get_committee_member(string owner_account)
 signed_transaction wallet_api::create_vesting_balance(string owner_account,
                                               string amount,
                                               string asset_symbol,
-                                              string vesting_type,
+                                              vesting_balance_type vesting_type,
                                               bool broadcast /* = false */)
 {
    return my->create_vesting_balance(owner_account, amount, asset_symbol, vesting_type, broadcast);

--- a/tests/cli/son.cpp
+++ b/tests/cli/son.cpp
@@ -79,11 +79,11 @@ public:
 
         // create deposit vesting
         fixture_.con.wallet_api_ptr->create_vesting_balance(account_name,
-                                                            "50", "1.3.0", "son", true);
+                                                            "50", "1.3.0", vesting_balance_type::son, true);
         BOOST_CHECK(fixture_.generate_block());
 
         // create pay_vb vesting
-        fixture_.con.wallet_api_ptr->create_vesting_balance(account_name, "1", "1.3.0", "normal", true);
+        fixture_.con.wallet_api_ptr->create_vesting_balance(account_name, "1", "1.3.0", vesting_balance_type::normal, true);
         BOOST_CHECK(fixture_.generate_block());
 
         // check deposits are here

--- a/tests/cli/son.cpp
+++ b/tests/cli/son.cpp
@@ -78,11 +78,12 @@ public:
         BOOST_CHECK(fixture_.generate_block());
 
         // create deposit vesting
-        fixture_.con.wallet_api_ptr->create_vesting(account_name, "50000000", "son", true);
+        fixture_.con.wallet_api_ptr->create_vesting_balance(account_name,
+                                                            "50", "1.3.0", "son", true);
         BOOST_CHECK(fixture_.generate_block());
 
         // create pay_vb vesting
-        fixture_.con.wallet_api_ptr->create_vesting(account_name, "1000000", "normal", true);
+        fixture_.con.wallet_api_ptr->create_vesting_balance(account_name, "1", "1.3.0", "normal", true);
         BOOST_CHECK(fixture_.generate_block());
 
         // check deposits are here


### PR DESCRIPTION
I've made it similar to `create_vesting_balance` call in GPOS branch and I have changed vesting_type argument as @oxarbitrage has described in  https://github.com/peerplays-network/peerplays/pull/179#discussion_r337750987 . 

Now cli wallet call should look like 
```
unlocked >>> create_vesting_balance nathan 50 TEST son true
```

@oxarbitrage, take a look, please,  is it what you mean?