### PR TITLE
[SON-113] Fix several issues in update_son_votes call in wallet_api 

### DIFF
--- a/libraries/chain/protocol/account.cpp
+++ b/libraries/chain/protocol/account.cpp
@@ -171,15 +171,22 @@ void account_options::validate() const
 {
    auto needed_witnesses = num_witness;
    auto needed_committee = num_committee;
+   auto needed_sons = num_son;
 
    for( vote_id_type id : votes )
       if( id.type() == vote_id_type::witness && needed_witnesses )
          --needed_witnesses;
       else if ( id.type() == vote_id_type::committee && needed_committee )
          --needed_committee;
+      else if ( id.type() == vote_id_type::son && needed_sons )
+         --needed_sons;
 
-   FC_ASSERT( needed_witnesses == 0 && needed_committee == 0,
-              "May not specify fewer witnesses or committee members than the number voted for.");
+   FC_ASSERT( needed_witnesses == 0,
+              "May not specify fewer witnesses than the number voted for.");
+   FC_ASSERT( needed_committee == 0,
+              "May not specify committee members than the number voted for.");
+   FC_ASSERT( needed_sons == 0,
+              "May not specify fewer SONs than the number voted for.");
 }
 
 void affiliate_reward_distribution::validate() const

--- a/libraries/chain/protocol/account.cpp
+++ b/libraries/chain/protocol/account.cpp
@@ -184,7 +184,7 @@ void account_options::validate() const
    FC_ASSERT( needed_witnesses == 0,
               "May not specify fewer witnesses than the number voted for.");
    FC_ASSERT( needed_committee == 0,
-              "May not specify committee members than the number voted for.");
+              "May not specify fewer committee members than the number voted for.");
    FC_ASSERT( needed_sons == 0,
               "May not specify fewer SONs than the number voted for.");
 }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2279,20 +2279,20 @@ public:
          account_id_type son_owner_account_id = get_account_id(son);
          fc::optional<son_object> son_obj = _remote_db->get_son_by_account(son_owner_account_id);
          if (!son_obj)
-            FC_THROW("Account ${son} is not registered as a witness", ("son", son));
+            FC_THROW("Account ${son} is not registered as a SON", ("son", son));
          auto insert_result = voting_account_object.options.votes.insert(son_obj->vote_id);
          if (!insert_result.second)
-            FC_THROW("Account ${account} was already voting for son ${son}", ("account", voting_account)("son", son));
+            FC_THROW("Account ${account} was already voting for SON ${son}", ("account", voting_account)("son", son));
       }
       for (const std::string& son : sons_to_reject)
       {
          account_id_type son_owner_account_id = get_account_id(son);
          fc::optional<son_object> son_obj = _remote_db->get_son_by_account(son_owner_account_id);
          if (!son_obj)
-            FC_THROW("Account ${son} is not registered as a son", ("son", son));
+            FC_THROW("Account ${son} is not registered as a SON", ("son", son));
          unsigned votes_removed = voting_account_object.options.votes.erase(son_obj->vote_id);
          if (!votes_removed)
-            FC_THROW("Account ${account} is already not voting for son ${son}", ("account", voting_account)("son", son));
+            FC_THROW("Account ${account} is already not voting for SON ${son}", ("account", voting_account)("son", son));
       }
       voting_account_object.options.num_son = desired_number_of_sons;
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2272,6 +2272,7 @@ public:
                                            uint16_t desired_number_of_sons,
                                            bool broadcast /* = false */)
    { try {
+      FC_ASSERT(sons_to_approve.size() || sons_to_reject.size(), "Both accepted and rejected lists can't be empty simultaneously");
       account_object voting_account_object = get_account(voting_account);
       for (const std::string& son : sons_to_approve)
       {

--- a/tests/cli/son.cpp
+++ b/tests/cli/son.cpp
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        accepted.push_back("son1account");
        accepted.push_back("son2account");
        update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
-                                                              rejected, 15, true);
+                                                              rejected, 2, true);
        BOOST_CHECK(generate_block());
        BOOST_CHECK(generate_maintenance_block());
 
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        rejected.clear();
        rejected.push_back("son1account");
        update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
-                                                              rejected, 15, true);
+                                                              rejected, 1, true);
        BOOST_CHECK(generate_maintenance_block());
 
        // Verify the votes
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        rejected.clear();
        rejected.push_back("son1accnt");
        BOOST_CHECK_THROW(update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
-                                                              rejected, 15, true), fc::exception);
+                                                              rejected, 1, true), fc::exception);
        BOOST_CHECK(generate_block());
 
        // Verify the votes
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        rejected.clear();
        rejected.push_back("son2account");
        update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
-                                                              rejected, 15, true);
+                                                              rejected, 0, true);
        BOOST_CHECK(generate_maintenance_block());
 
        // Verify the votes
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        rejected.push_back("son1accnt");
        accepted.push_back("son1accnt");
        BOOST_REQUIRE_THROW(update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
-                                                              rejected, 15, true), fc::exception);
+                                                              rejected, 1, true), fc::exception);
        BOOST_CHECK(generate_maintenance_block());
 
        // Verify the votes
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        accepted.clear();
        rejected.clear();
        BOOST_REQUIRE_THROW(update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
-                                                              rejected, 15, true), fc::exception);
+                                                              rejected, 1, true), fc::exception);
        BOOST_CHECK(generate_maintenance_block());
 
        // Verify the votes

--- a/tests/cli/son.cpp
+++ b/tests/cli/son.cpp
@@ -481,6 +481,23 @@ BOOST_AUTO_TEST_CASE( update_son_votes_test )
        BOOST_CHECK(son2_end_votes == son2_start_votes);
        son2_start_votes = son2_end_votes;
 
+       // Try to accept and reject empty lists
+       accepted.clear();
+       rejected.clear();
+       BOOST_REQUIRE_THROW(update_votes_tx = con.wallet_api_ptr->update_son_votes("nathan", accepted,
+                                                              rejected, 15, true), fc::exception);
+       BOOST_CHECK(generate_maintenance_block());
+
+       // Verify the votes
+       son1_obj = con.wallet_api_ptr->get_son("son1account");
+       son1_end_votes = son1_obj.total_votes;
+       BOOST_CHECK(son1_end_votes == son1_start_votes);
+       son1_start_votes = son1_end_votes;
+       son2_obj = con.wallet_api_ptr->get_son("son2account");
+       son2_end_votes = son2_obj.total_votes;
+       BOOST_CHECK(son2_end_votes == son2_start_votes);
+       son2_start_votes = son2_end_votes;
+
     } catch( fc::exception& e ) {
        BOOST_TEST_MESSAGE("SON cli wallet tests exception");
        edump((e.to_detail_string()));


### PR DESCRIPTION
 - accepted and rejected SONs lists can't be empty simultaneously;
 - fix incorrect error message for wrong accepted SON;
 - check number of SONs against votes number in account_object (similar to witness and committee member number);