### PR TITLE
[SON-165] create_son: Issue with signing key

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -188,7 +188,6 @@ struct wallet_data
    //    incomplete account regs
    map<string, vector<string> > pending_account_registrations;
    map<string, string> pending_witness_registrations;
-   map<string, string> pending_son_registrations;
 
    key_label_index_type                                              labeled_keys;
    blind_receipt_index_type                                          blind_receipts;
@@ -1999,7 +1998,7 @@ FC_REFLECT( graphene::wallet::wallet_data,
             (my_accounts)
             (cipher_keys)
             (extra_keys)
-            (pending_account_registrations)(pending_witness_registrations)(pending_son_registrations)
+            (pending_account_registrations)(pending_witness_registrations)
             (labeled_keys)
             (blind_receipts)
             (committed_game_moves)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -293,23 +293,6 @@ private:
       _wallet.pending_account_registrations.erase( it );
    }
 
-   // after a son registration succeeds, this saves the private key in the wallet permanently
-   //
-   void claim_registered_son(const std::string& son_name)
-   {
-      auto iter = _wallet.pending_son_registrations.find(son_name);
-      FC_ASSERT(iter != _wallet.pending_son_registrations.end());
-      std::string wif_key = iter->second;
-
-      // get the list key id this key is registered with in the chain
-      fc::optional<fc::ecc::private_key> son_private_key = wif_to_key(wif_key);
-      FC_ASSERT(son_private_key);
-
-      auto pub_key = son_private_key->get_public_key();
-      _keys[pub_key] = wif_key;
-      _wallet.pending_son_registrations.erase(iter);
-   }
-
    // after a witness registration succeeds, this saves the private key in the wallet permanently
    //
    void claim_registered_witness(const std::string& witness_name)
@@ -369,24 +352,6 @@ private:
                fc::optional<witness_object> witness_obj = _remote_db->get_witness_by_account(optional_account->id);
                if (witness_obj)
                   claim_registered_witness(optional_account->name);
-            }
-      }
-
-      if (!_wallet.pending_son_registrations.empty())
-      {
-         // make a vector of the owner accounts for sons pending registration
-         std::vector<string> pending_son_names = boost::copy_range<std::vector<string> >(boost::adaptors::keys(_wallet.pending_son_registrations));
-
-         // look up the owners on the blockchain
-         std::vector<fc::optional<graphene::chain::account_object>> owner_account_objects = _remote_db->lookup_account_names(pending_son_names);
-
-         // if any of them have registered sons, claim them
-         for( const fc::optional<graphene::chain::account_object>& optional_account : owner_account_objects )
-            if (optional_account)
-            {
-               fc::optional<son_object> son_obj = _remote_db->get_son_by_account(optional_account->id);
-               if (son_obj)
-                  claim_registered_son(optional_account->name);
             }
       }
    }
@@ -1865,10 +1830,7 @@ public:
                                  bool broadcast /* = false */)
    { try {
       account_object son_account = get_account(owner_account);
-      fc::ecc::private_key active_private_key = get_private_key_for_account(son_account);
-      int son_key_index = find_first_unused_derived_key_index(active_private_key);
-      fc::ecc::private_key son_private_key = derive_private_key(key_to_wif(active_private_key), son_key_index);
-      graphene::chain::public_key_type son_public_key = son_private_key.get_public_key();
+      auto son_public_key = son_account.active.get_keys()[0];
 
       son_create_operation son_create_op;
       son_create_op.owner_account = son_account.id;
@@ -1884,8 +1846,6 @@ public:
       tx.operations.push_back( son_create_op );
       set_operation_fees( tx, _remote_db->get_global_properties().parameters.current_fees);
       tx.validate();
-
-      _wallet.pending_son_registrations[owner_account] = key_to_wif(son_private_key);
 
       return sign_transaction( tx, broadcast );
    } FC_CAPTURE_AND_RETHROW( (owner_account)(broadcast) ) }


### PR DESCRIPTION
Removed the derivation of keys and related code from `create_son`. Cli wallet command will just use the first active key as the signing key. 