### PR TITLE
[BLOCKBACK-182] set extensions default values

### DIFF
--- a/libraries/chain/committee_member_evaluator.cpp
+++ b/libraries/chain/committee_member_evaluator.cpp
@@ -77,15 +77,7 @@ void_result committee_member_update_evaluator::do_apply( const committee_member_
 void_result committee_member_update_global_parameters_evaluator::do_evaluate(const committee_member_update_global_parameters_operation& o)
 { try {
    FC_ASSERT(trx_state->_is_proposed_trx);
-
-   if( db().head_block_time() < HARDFORK_1000_TIME ) // TODO: remove after hf
-      FC_ASSERT( !o.new_parameters.extensions.value.min_bet_multiplier.valid()
-                 && !o.new_parameters.extensions.value.max_bet_multiplier.valid()
-                 && !o.new_parameters.extensions.value.betting_rake_fee_percentage.valid()
-                 && !o.new_parameters.extensions.value.permitted_betting_odds_increments.valid()
-                 && !o.new_parameters.extensions.value.live_betting_delay_time.valid(),
-                 "Parameter extensions are not allowed yet!" );
-
+   
    dgpo = &db().get_global_properties();
    if( o.new_parameters.extensions.value.min_bet_multiplier.valid()
         && !o.new_parameters.extensions.value.max_bet_multiplier.valid() )

--- a/libraries/chain/include/graphene/chain/protocol/chain_parameters.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/chain_parameters.hpp
@@ -34,19 +34,20 @@ namespace graphene { namespace chain { struct fee_schedule; } }
 namespace graphene { namespace chain {
    struct parameter_extension
    {
-      optional< bet_multiplier_type > min_bet_multiplier;
-      optional< bet_multiplier_type > max_bet_multiplier;
-      optional< uint16_t >            betting_rake_fee_percentage;
-      optional< flat_map<bet_multiplier_type, bet_multiplier_type> > permitted_betting_odds_increments;
-      optional< uint16_t >            live_betting_delay_time;
-      optional< uint16_t >            sweeps_distribution_percentage;
-      optional< asset_id_type >       sweeps_distribution_asset;
-      optional< account_id_type >     sweeps_vesting_accumulator_account;
+      optional< bet_multiplier_type > min_bet_multiplier                = GRAPHENE_DEFAULT_MIN_BET_MULTIPLIER;
+      optional< bet_multiplier_type > max_bet_multiplier                = GRAPHENE_DEFAULT_MAX_BET_MULTIPLIER;
+      optional< uint16_t >            betting_rake_fee_percentage       = GRAPHENE_DEFAULT_RAKE_FEE_PERCENTAGE;
+      optional< flat_map<bet_multiplier_type, bet_multiplier_type> > 
+      permitted_betting_odds_increments                                 = flat_map<bet_multiplier_type, bet_multiplier_type>(GRAPHENE_DEFAULT_PERMITTED_BETTING_ODDS_INCREMENTS);
+      optional< uint16_t >            live_betting_delay_time           = GRAPHENE_DEFAULT_LIVE_BETTING_DELAY_TIME;
+      optional< uint16_t >            sweeps_distribution_percentage    = SWEEPS_DEFAULT_DISTRIBUTION_PERCENTAGE;
+      optional< asset_id_type >       sweeps_distribution_asset         = SWEEPS_DEFAULT_DISTRIBUTION_ASSET;
+      optional< account_id_type >     sweeps_vesting_accumulator_account= SWEEPS_ACCUMULATOR_ACCOUNT;
       /* gpos parameters */
-      optional < uint32_t >           gpos_period;
-      optional < uint32_t >           gpos_subperiod;
+      optional < uint32_t >           gpos_period                       = GPOS_PERIOD;
+      optional < uint32_t >           gpos_subperiod                    = GPOS_SUBPERIOD;
       optional < uint32_t >           gpos_period_start;
-      optional < uint32_t >           gpos_vesting_lockin_period;
+      optional < uint32_t >           gpos_vesting_lockin_period        = GPOS_VESTING_LOCKIN_PERIOD;
    };
 
    struct chain_parameters

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -45,15 +45,7 @@ struct proposal_operation_hardfork_visitor
    template<typename T>
    void operator()(const T &v) const {}
 
-   void operator()(const committee_member_update_global_parameters_operation &op) const {
-      if( block_time < HARDFORK_1000_TIME ) // TODO: remove after hf
-         FC_ASSERT( !op.new_parameters.extensions.value.min_bet_multiplier.valid()
-                    && !op.new_parameters.extensions.value.max_bet_multiplier.valid()
-                    && !op.new_parameters.extensions.value.betting_rake_fee_percentage.valid()
-                    && !op.new_parameters.extensions.value.permitted_betting_odds_increments.valid()
-                    && !op.new_parameters.extensions.value.live_betting_delay_time.valid(),
-                    "Parameter extensions are not allowed yet!" );
-   }
+   void operator()(const committee_member_update_global_parameters_operation &op) const {}
 
    void operator()(const graphene::chain::tournament_payout_operation &o) const {
       // TODO: move check into tournament_payout_operation::validate after HARDFORK_999_TIME


### PR DESCRIPTION
The `extension` section of chain parameters remains empty until the committee proposal is submitted. This is fixed by setting the default values of all extensions parameters.

Also, removed the old hardfork betting checks which were required to be removed after the hf.