### PR TITLE
BLOCKBACK-186 fix: GPOS

### DIFF
--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -119,7 +119,9 @@ struct gpos_info {
    asset award;
    share_type total_amount;
    uint32_t current_subperiod;
-   fc::time_point_sec last_voted_time;   
+   fc::time_point_sec last_voted_time;
+   share_type allowed_withdraw_amount;
+   share_type account_vested_balance;
 };
 
 /**
@@ -722,7 +724,7 @@ FC_REFLECT( graphene::app::order_book, (base)(quote)(bids)(asks) );
 FC_REFLECT( graphene::app::market_ticker, (base)(quote)(latest)(lowest_ask)(highest_bid)(percent_change)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_volume, (base)(quote)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_trade, (date)(price)(amount)(value) );
-FC_REFLECT( graphene::app::gpos_info, (vesting_factor)(award)(total_amount)(current_subperiod)(last_voted_time) );
+FC_REFLECT( graphene::app::gpos_info, (vesting_factor)(award)(total_amount)(current_subperiod)(last_voted_time)(allowed_withdraw_amount)(account_vested_balance) );
 
 
 FC_API(graphene::app::database_api,

--- a/libraries/chain/include/graphene/chain/protocol/chain_parameters.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/chain_parameters.hpp
@@ -47,7 +47,7 @@ namespace graphene { namespace chain {
       /* gpos parameters */
       optional < uint32_t >           gpos_period                       = GPOS_PERIOD;
       optional < uint32_t >           gpos_subperiod                    = GPOS_SUBPERIOD;
-      optional < uint32_t >           gpos_period_start;
+      optional < uint32_t >           gpos_period_start                 = HARDFORK_GPOS_TIME.sec_since_epoch();
       optional < uint32_t >           gpos_vesting_lockin_period        = GPOS_VESTING_LOCKIN_PERIOD;
    };
 

--- a/libraries/chain/include/graphene/chain/protocol/vesting.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/vesting.hpp
@@ -112,6 +112,7 @@ namespace graphene { namespace chain {
       vesting_balance_id_type vesting_balance;
       account_id_type         owner; ///< Must be vesting_balance.owner
       asset                   amount;
+      vesting_balance_type    balance_type;
 
       account_id_type   fee_payer()const { return owner; }
       void              validate()const
@@ -127,7 +128,7 @@ FC_REFLECT( graphene::chain::vesting_balance_create_operation::fee_parameters_ty
 FC_REFLECT( graphene::chain::vesting_balance_withdraw_operation::fee_parameters_type, (fee) )
 
 FC_REFLECT( graphene::chain::vesting_balance_create_operation, (fee)(creator)(owner)(amount)(policy)(balance_type) )
-FC_REFLECT( graphene::chain::vesting_balance_withdraw_operation, (fee)(vesting_balance)(owner)(amount) )
+FC_REFLECT( graphene::chain::vesting_balance_withdraw_operation, (fee)(vesting_balance)(owner)(amount)(balance_type) )
 
 FC_REFLECT(graphene::chain::linear_vesting_policy_initializer, (begin_timestamp)(vesting_cliff_seconds)(vesting_duration_seconds) )
 FC_REFLECT(graphene::chain::cdd_vesting_policy_initializer, (start_claim)(vesting_seconds) )

--- a/libraries/chain/vesting_balance_evaluator.cpp
+++ b/libraries/chain/vesting_balance_evaluator.cpp
@@ -143,11 +143,33 @@ void_result vesting_balance_withdraw_evaluator::do_evaluate( const vesting_balan
    const database& d = db();
    const time_point_sec now = d.head_block_time();
 
-   const vesting_balance_object& vbo = op.vesting_balance( d );
-   FC_ASSERT( op.owner == vbo.owner, "", ("op.owner", op.owner)("vbo.owner", vbo.owner) );
-   FC_ASSERT( vbo.is_withdraw_allowed( now, op.amount ), "Account has either insufficient ${balance_type} Vested Balance or lock-in period is not matured", 
-         ("balance_type", get_vesting_balance_type(vbo.balance_type))("now", now)("op", op)("vbo", vbo) );
-   assert( op.amount <= vbo.balance );      // is_withdraw_allowed should fail before this check is reached
+   if(op.balance_type == vesting_balance_type::gpos)
+   {
+      const account_id_type account_id = op.owner;
+      vector<vesting_balance_object> vbos;
+      auto vesting_range = d.get_index_type<vesting_balance_index>().indices().get<by_account>().equal_range(account_id);
+      std::for_each(vesting_range.first, vesting_range.second,
+                    [&vbos, now](const vesting_balance_object& balance) {
+                        if(balance.balance.amount > 0 && balance.balance_type == vesting_balance_type::gpos
+                         && balance.is_withdraw_allowed(now, balance.balance.amount) && balance.balance.asset_id == asset_id_type())
+                           vbos.emplace_back(balance);
+                    });
+
+      asset total_amount;
+      for (const vesting_balance_object& vesting_balance_obj : vbos)
+      {
+         total_amount += vesting_balance_obj.balance.amount;
+      }
+      FC_ASSERT( op.amount <= total_amount, "Account has either insufficient GPOS Vested Balance or lock-in period is not matured");
+   }
+   else
+   {
+      const vesting_balance_object& vbo = op.vesting_balance( d );
+      FC_ASSERT( op.owner == vbo.owner, "", ("op.owner", op.owner)("vbo.owner", vbo.owner) );
+      FC_ASSERT( vbo.is_withdraw_allowed( now, op.amount ), "Account has either insufficient ${balance_type} Vested Balance to withdraw",
+            ("balance_type", get_vesting_balance_type(vbo.balance_type))("now", now)("op", op)("vbo", vbo) );
+      assert( op.amount <= vbo.balance );      // is_withdraw_allowed should fail before this check is reached
+   }
 
    /* const account_object& owner_account =  op.owner( d ); */
    // TODO: Check asset authorizations and withdrawals
@@ -159,21 +181,54 @@ void_result vesting_balance_withdraw_evaluator::do_apply( const vesting_balance_
    database& d = db();
 
    const time_point_sec now = d.head_block_time();
-
-   const vesting_balance_object& vbo = op.vesting_balance( d );
-
-   // Allow zero balance objects to stick around, (1) to comply
-   // with the chain's "objects live forever" design principle, (2)
-   // if it's cashback or worker, it'll be filled up again.
-
-   d.modify( vbo, [&]( vesting_balance_object& vbo )
+   //Handling all GPOS withdrawls separately from normal and SONs(future extension).
+   // One request/transaction would be sufficient to withdraw from multiple vesting balance ids
+   if(op.balance_type == vesting_balance_type::gpos)
    {
-      vbo.withdraw( now, op.amount );
-   } );
+      const account_id_type account_id = op.owner;
+      vector<vesting_balance_id_type> ids;
+      auto vesting_range = d.get_index_type<vesting_balance_index>().indices().get<by_account>().equal_range(account_id);
+      std::for_each(vesting_range.first, vesting_range.second,
+                    [&ids, now](const vesting_balance_object& balance) {
+                        if(balance.balance.amount > 0 && balance.balance_type == vesting_balance_type::gpos
+                         && balance.balance.asset_id == asset_id_type())
+                           ids.emplace_back(balance.id);
+                    });
 
-   d.adjust_balance( op.owner, op.amount );
+      asset total_withdraw_amount = op.amount;
+      for (const vesting_balance_id_type& id : ids)
+      {
+         const vesting_balance_object& vbo = id( d );
+         if(total_withdraw_amount.amount > vbo.balance.amount)
+         {
+            total_withdraw_amount.amount -= vbo.balance.amount;
+            d.modify( vbo, [&]( vesting_balance_object& vbo ) {vbo.withdraw( now, vbo.balance );} );
+            d.adjust_balance( op.owner, vbo.balance );            
+         }
+         else
+         {
+            d.modify( vbo, [&]( vesting_balance_object& vbo ) {vbo.withdraw( now, total_withdraw_amount );} );
+            d.adjust_balance( op.owner, total_withdraw_amount);
+            break;
+         }
+      }
+   }
+   else
+   {
+      const vesting_balance_object& vbo = op.vesting_balance( d );
 
-   // TODO: Check asset authorizations and withdrawals
+      // Allow zero balance objects to stick around, (1) to comply
+      // with the chain's "objects live forever" design principle, (2)
+      // if it's cashback or worker, it'll be filled up again.
+
+      d.modify( vbo, [&]( vesting_balance_object& vbo )
+      {
+         vbo.withdraw( now, op.amount );
+      } );
+
+      d.adjust_balance( op.owner, op.amount );
+   }
+
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2133,47 +2133,18 @@ public:
       if(!vbos.size())
          vbos.emplace_back( get_object<vesting_balance_object>(*vbid) );
  
+      const vesting_balance_object& vbo = vbos.front();
+
+      vesting_balance_withdraw_operation vesting_balance_withdraw_op;
+
+      vesting_balance_withdraw_op.vesting_balance = vbo.id;
+      vesting_balance_withdraw_op.owner = vbo.owner;
+      vesting_balance_withdraw_op.amount = asset_obj.amount_from_string(amount);
+      vesting_balance_withdraw_op.balance_type = vesting_balance_type::gpos;
+
       signed_transaction tx;
-      asset withdraw_amount = asset_obj.amount_from_string(amount);
-      bool onetime_fee_paid = false;
-            
-      for(const vesting_balance_object& vbo: vbos )
-      {         
-         if((vbo.balance_type == vesting_balance_type::gpos) && vbo.balance.amount > 0)
-         {
-            fc::optional<vesting_balance_id_type> vest_id = vbo.id;
-            vesting_balance_withdraw_operation vesting_balance_withdraw_op;
-
-            // Since there are multiple vesting objects, below logic with vesting_balance_evaluator.cpp changes will
-            // deduct fee from single object and set withdrawl fee to 0 for rest of objects based on requested amount.
-            if(onetime_fee_paid)
-               vesting_balance_withdraw_op.fee = asset( 0, asset_id_type() );
-            else
-               vesting_balance_withdraw_op.fee = _remote_db->get_global_properties().parameters.current_fees->calculate_fee(vesting_balance_withdraw_op);
-
-            vesting_balance_withdraw_op.vesting_balance = *vest_id;
-            vesting_balance_withdraw_op.owner = vbo.owner;
-            if(withdraw_amount.amount > vbo.balance.amount)
-            {
-               vesting_balance_withdraw_op.amount = vbo.balance.amount;
-               withdraw_amount.amount -= vbo.balance.amount;
-            }
-            else
-            {
-               vesting_balance_withdraw_op.amount = withdraw_amount.amount;
-               tx.operations.push_back( vesting_balance_withdraw_op );
-               withdraw_amount.amount -= vbo.balance.amount;
-               break;
-            }     
-
-            tx.operations.push_back( vesting_balance_withdraw_op );
-            onetime_fee_paid = true;
-         }
-      }
-
-      if( withdraw_amount.amount > 0)
-         FC_THROW("Account has NO or Insufficient balance to withdraw");
-
+      tx.operations.push_back( vesting_balance_withdraw_op );
+      set_operation_fees( tx, _remote_db->get_global_properties().parameters.current_fees );
       tx.validate();
 
       return sign_transaction( tx, broadcast );


### PR DESCRIPTION
Move GPOS withdraw logic to evaluator to have single transaction(also single fee) from frontend
Update `get_gpos_info` API to list 1) User Vested Balance 2) Allowed Withdraw Amount
Update default chain parameter info to list GPOS period start on extension parameters(get_global_properties command from cli_wallet would display all chain parameters )