### PR TITLE
[GRPH-167] 64 bit uint changes

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -641,9 +641,9 @@ namespace graphene { namespace app {
 
 
     vector<operation_history_object> history_api::get_relative_account_history( const std::string account_id_or_name,
-                                                                                uint32_t stop,
+                                                                                uint64_t stop,
                                                                                 unsigned limit,
-                                                                                uint32_t start) const
+                                                                                uint64_t start) const
     {
        FC_ASSERT( _app.chain_database() );
        const auto& db = *_app.chain_database();

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -139,9 +139,9 @@ namespace graphene { namespace app {
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
          vector<operation_history_object> get_relative_account_history( const std::string account_id_or_name,
-                                                                        uint32_t stop = 0,
+                                                                        uint64_t stop = 0,
                                                                         unsigned limit = 100,
-                                                                        uint32_t start = 0) const;
+                                                                        uint64_t start = 0) const;
 
          vector<order_history_object> get_fill_order_history( std::string asset_a, std::string asset_b, uint32_t limit )const;
          vector<bucket_object> get_market_history( std::string asset_a, std::string asset_b, uint32_t bucket_seconds,

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -54,9 +54,9 @@ namespace graphene { namespace chain {
           */
          account_transaction_history_id_type most_recent_op;
          /** Total operations related to this account. */
-         uint32_t                            total_ops = 0;
+         uint64_t                            total_ops = 0;
          /** Total operations related to this account that has been removed from the database. */
-         uint32_t                            removed_ops = 0;
+         uint64_t                            removed_ops = 0;
 
          /**
           * When calculating votes it is necessary to know how much is stored in orders (and thus unavailable for

--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -151,7 +151,7 @@
 #define GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT             4
 #define GRAPHENE_RECENTLY_MISSED_COUNT_DECREMENT             3
 
-#define GRAPHENE_CURRENT_DB_VERSION                          "PPY2.3"
+#define GRAPHENE_CURRENT_DB_VERSION                          "PPY2.4"
 
 #define GRAPHENE_IRREVERSIBLE_THRESHOLD                      (70 * GRAPHENE_1_PERCENT)
 

--- a/libraries/chain/include/graphene/chain/operation_history_object.hpp
+++ b/libraries/chain/include/graphene/chain/operation_history_object.hpp
@@ -94,7 +94,7 @@ namespace graphene { namespace chain {
          static const uint8_t type_id  = impl_account_transaction_history_object_type;
          account_id_type                      account; /// the account this operation applies to
          operation_history_id_type            operation_id;
-         uint32_t                             sequence = 0; /// the operation position within the given account
+         uint64_t                             sequence = 0; /// the operation position within the given account
          account_transaction_history_id_type  next;
    };
    
@@ -109,7 +109,7 @@ typedef multi_index_container<
       ordered_unique< tag<by_seq>,
          composite_key< account_transaction_history_object,
             member< account_transaction_history_object, account_id_type, &account_transaction_history_object::account>,
-            member< account_transaction_history_object, uint32_t, &account_transaction_history_object::sequence>
+            member< account_transaction_history_object, uint64_t, &account_transaction_history_object::sequence>
          >
       >,
       ordered_unique< tag<by_op>,

--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -66,7 +66,7 @@ class account_history_plugin_impl
       flat_set<account_id_type> _tracked_accounts;
       bool _partial_operations = false;
       primary_index< simple_index< operation_history_object > >* _oho_index;
-      uint32_t _max_ops_per_account = -1;
+      uint64_t _max_ops_per_account = -1;
    private:
       /** add one history record, then check and remove the earliest history record */
       void add_account_history( const account_id_type account_id, const operation_history_id_type op_id );
@@ -299,7 +299,7 @@ void account_history_plugin::plugin_initialize(const boost::program_options::var
        my->_partial_operations = options["partial-operations"].as<bool>();
    }
    if (options.count("max-ops-per-account")) {
-       my->_max_ops_per_account = options["max-ops-per-account"].as<uint32_t>();
+       my->_max_ops_per_account = options["max-ops-per-account"].as<uint64_t>();
    }
 }
 


### PR DESCRIPTION
There are 32 bit variables all throughout the code. Each one could stand to be reviewed. This PR takes care of a few that were being used as counters that could overflow.