### PR TITLE
Avoid proposal failure messages on running tests and release mode

### DIFF
--- a/libraries/chain/proposal_object.cpp
+++ b/libraries/chain/proposal_object.cpp
@@ -43,7 +43,9 @@ bool proposal_object::is_authorized_to_execute(database& db) const
    } 
    catch ( const fc::exception& e )
    {
-      elog( "caught exception ${e} while checking authorization of proposal operations",("e", e.to_detail_string()) );
+#ifndef NDEBUG
+      wlog( "caught exception ${e} while checking authorization of proposal operations",("e", e.to_detail_string()) );
+#endif
       return false;
    }
    return true;


### PR DESCRIPTION
Getting this error log multiple times while running the `betting_test` and `chain_test`. Reduced log level and will need to log only for Debug mode.