### PR TITLE
Make new fields in vesting create and withdraw operations optional

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/vesting.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/vesting.hpp
@@ -80,12 +80,12 @@ namespace graphene { namespace chain {
    {
       struct fee_parameters_type { uint64_t fee = GRAPHENE_BLOCKCHAIN_PRECISION; };
 
-      asset                       fee;
-      account_id_type             creator; ///< Who provides funds initially
-      account_id_type             owner; ///< Who is able to withdraw the balance
-      asset                       amount;
-      vesting_policy_initializer  policy;
-      vesting_balance_type        balance_type;
+      asset                            fee;
+      account_id_type                  creator; ///< Who provides funds initially
+      account_id_type                  owner; ///< Who is able to withdraw the balance
+      asset                            amount;
+      vesting_policy_initializer       policy;
+      optional<vesting_balance_type>   balance_type;
 
       account_id_type   fee_payer()const { return creator; }
       void              validate()const
@@ -108,11 +108,11 @@ namespace graphene { namespace chain {
    {
       struct fee_parameters_type { uint64_t fee = 20*GRAPHENE_BLOCKCHAIN_PRECISION; };
 
-      asset                   fee;
-      vesting_balance_id_type vesting_balance;
-      account_id_type         owner; ///< Must be vesting_balance.owner
-      asset                   amount;
-      vesting_balance_type    balance_type;
+      asset                            fee;
+      vesting_balance_id_type          vesting_balance;
+      account_id_type                  owner; ///< Must be vesting_balance.owner
+      asset                            amount;
+      optional<vesting_balance_type>   balance_type;
 
       account_id_type   fee_payer()const { return owner; }
       void              validate()const

--- a/libraries/chain/include/graphene/chain/protocol/vesting.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/vesting.hpp
@@ -127,8 +127,8 @@ namespace graphene { namespace chain {
 FC_REFLECT( graphene::chain::vesting_balance_create_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::vesting_balance_withdraw_operation::fee_parameters_type, (fee) )
 
-FC_REFLECT( graphene::chain::vesting_balance_create_operation, (fee)(creator)(owner)(amount)(policy)(balance_type) )
-FC_REFLECT( graphene::chain::vesting_balance_withdraw_operation, (fee)(vesting_balance)(owner)(amount)(balance_type) )
+FC_REFLECT( graphene::chain::vesting_balance_create_operation, (fee)(creator)(owner)(amount)(policy) )
+FC_REFLECT( graphene::chain::vesting_balance_withdraw_operation, (fee)(vesting_balance)(owner)(amount) )
 
 FC_REFLECT(graphene::chain::linear_vesting_policy_initializer, (begin_timestamp)(vesting_cliff_seconds)(vesting_duration_seconds) )
 FC_REFLECT(graphene::chain::cdd_vesting_policy_initializer, (start_claim)(vesting_seconds) )

--- a/libraries/chain/vesting_balance_evaluator.cpp
+++ b/libraries/chain/vesting_balance_evaluator.cpp
@@ -108,7 +108,8 @@ object_id_type vesting_balance_create_evaluator::do_apply( const vesting_balance
       else {
          op.policy.visit(init_policy_visitor(obj.policy, op.amount.amount, now));
       }
-      obj.balance_type = op.balance_type;
+      if(op.balance_type)
+         obj.balance_type = *op.balance_type;
    } );
 
 


### PR DESCRIPTION
Fix for the https://github.com/peerplays-network/peerplays/issues/249

Block 1623665 contains transaction with `vesting_balance_withdraw_operation` without new field ,  so new code can't unpack this operation and block.