### PR TITLE
[SON-202] Implement cli_wallet commands for maintenance mode

### DIFF
--- a/libraries/app/impacted.cpp
+++ b/libraries/app/impacted.cpp
@@ -310,6 +310,9 @@ struct get_impacted_account_visitor
    void operator()( const son_heartbeat_operation& op ){
       _impacted.insert( op.owner_account );
    }
+   void operator()( const son_maintenance_operation& op ){
+      _impacted.insert( op.owner_account );
+   }
    void operator()( const sidechain_address_add_operation& op ){
         _impacted.insert( op.sidechain_address_account );
    }

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -250,6 +250,7 @@ void database::initialize_evaluators()
    register_evaluator<update_son_evaluator>();
    register_evaluator<delete_son_evaluator>();
    register_evaluator<son_heartbeat_evaluator>();
+   register_evaluator<son_maintenance_evaluator>();
    register_evaluator<add_sidechain_address_evaluator>();
    register_evaluator<update_sidechain_address_evaluator>();
    register_evaluator<delete_sidechain_address_evaluator>();

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -471,17 +471,55 @@ void database::update_active_sons()
    } else {
       ilog( "Active SONs set CHANGED" );
       // Store new SON info, initiate wallet recreation and transfer of funds
-      for( const son_object& son : cur_active_sons )
+      vector<son_info> sons_to_remove;
+      // find all cur_active_sons members that is not in new_active_sons
+      for_each(cur_active_sons.begin(), cur_active_sons.end(),
+               [&sons_to_remove, &new_active_sons](const son_info& si)
+               {
+                  if(std::find(new_active_sons.begin(), new_active_sons.end(), si) ==
+                        new_active_sons.end())
+                  {
+                     sons_to_remove.push_back(si);
+                  }
+               }
+      );
+      const auto& idx = get_index_type<son_index>().indices().get<by_id>();
+      for( const son_info& si : sons_to_remove )
       {
-         modify( son, [&]( son_object& obj ){
-                 obj.status = son_status::inactive;
-                 });
+         auto son = idx.find( si.son_id );
+         if(son == idx.end()) // SON is deleted already
+            continue;
+         // keep maintenance status for nodes becoming inactive
+         if(son->status == son_status::active)
+         {
+            modify( *son, [&]( son_object& obj ){
+                    obj.status = son_status::inactive;
+                    });
+         }
       }
-      for( const son_object& son : new_active_sons )
+      vector<son_info> sons_to_add;
+      // find all new_active_sons members that is not in cur_active_sons
+      for_each(new_active_sons.begin(), new_active_sons.end(),
+               [&sons_to_add, &cur_active_sons](const son_info& si)
+               {
+                  if(std::find(cur_active_sons.begin(), cur_active_sons.end(), si) ==
+                        cur_active_sons.end())
+                  {
+                     sons_to_add.push_back(si);
+                  }
+               }
+      );
+      for( const son_info& si : sons_to_add )
       {
-         modify( son, [&]( son_object& obj ){
-                 obj.status = son_status::active;
-                 });
+         auto son = idx.find( si.son_id );
+         FC_ASSERT(son != idx.end(), "Invalid SON in active list, id={sonid}.", ("sonid", si.son_id));
+         // keep maintenance status for new nodes
+         if(son->status == son_status::inactive)
+         {
+            modify( *son, [&]( son_object& obj ){
+                    obj.status = son_status::active;
+                    });
+         }
       }
    }
 

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -471,6 +471,18 @@ void database::update_active_sons()
    } else {
       ilog( "Active SONs set CHANGED" );
       // Store new SON info, initiate wallet recreation and transfer of funds
+      for( const son_object& son : cur_active_sons )
+      {
+         modify( son, [&]( son_object& obj ){
+                 obj.status = son_status::inactive;
+                 });
+      }
+      for( const son_object& son : new_active_sons )
+      {
+         modify( son, [&]( son_object& obj ){
+                 obj.status = son_status::active;
+                 });
+      }
    }
 
    modify(gpo, [&]( global_property_object& gp ){

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -297,6 +297,9 @@ struct get_impacted_account_visitor
    void operator()( const son_heartbeat_operation& op ) {
       _impacted.insert( op.owner_account );
    }
+   void operator()( const son_maintenance_operation& op ) {
+      _impacted.insert( op.owner_account );
+   }
    void operator()( const sidechain_address_add_operation& op ) {
       _impacted.insert( op.sidechain_address_account );
    }

--- a/libraries/chain/include/graphene/chain/protocol/operations.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/operations.hpp
@@ -145,7 +145,8 @@ namespace graphene { namespace chain {
             sidechain_address_add_operation,
             sidechain_address_update_operation,
             sidechain_address_delete_operation,
-            son_report_down_operation
+            son_report_down_operation,
+            son_maintenance_operation
          > operation;
 
    /// @} // operations group

--- a/libraries/chain/include/graphene/chain/protocol/son.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/son.hpp
@@ -63,6 +63,7 @@ namespace graphene { namespace chain {
         share_type      calculate_fee(const fee_parameters_type& k)const { return 0; }
     };
 
+
     struct son_report_down_operation : public base_operation
     {
         struct fee_parameters_type { uint64_t fee = 0; };
@@ -73,6 +74,18 @@ namespace graphene { namespace chain {
         time_point_sec down_ts;
 
         account_id_type fee_payer()const { return payer; }
+        share_type      calculate_fee(const fee_parameters_type& k)const { return 0; }
+    };
+
+    struct son_maintenance_operation : public base_operation
+    {
+        struct fee_parameters_type { uint64_t fee = 0; };
+
+        asset fee;
+        son_id_type son_id;
+        account_id_type owner_account;
+
+        account_id_type fee_payer()const { return owner_account; }
         share_type      calculate_fee(const fee_parameters_type& k)const { return 0; }
     };
 
@@ -94,3 +107,6 @@ FC_REFLECT(graphene::chain::son_heartbeat_operation, (fee)(son_id)(owner_account
 
 FC_REFLECT(graphene::chain::son_report_down_operation::fee_parameters_type, (fee) )
 FC_REFLECT(graphene::chain::son_report_down_operation, (fee)(son_id)(payer)(down_ts) )
+
+FC_REFLECT(graphene::chain::son_maintenance_operation::fee_parameters_type, (fee) )
+FC_REFLECT(graphene::chain::son_maintenance_operation, (fee)(son_id)(owner_account) )

--- a/libraries/chain/include/graphene/chain/son_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/son_evaluator.hpp
@@ -49,4 +49,13 @@ public:
     object_id_type do_apply(const son_report_down_operation& o);
 };
 
+class son_maintenance_evaluator : public evaluator<son_maintenance_evaluator>
+{
+public:
+    typedef son_maintenance_operation operation_type;
+
+    void_result do_evaluate(const son_maintenance_operation& o);
+    object_id_type do_apply(const son_maintenance_operation& o);
+};
+
 } } // namespace graphene::chain

--- a/libraries/chain/include/graphene/chain/son_object.hpp
+++ b/libraries/chain/include/graphene/chain/son_object.hpp
@@ -97,7 +97,7 @@ namespace graphene { namespace chain {
 FC_REFLECT_ENUM(graphene::chain::son_status, (inactive)(active)(in_maintenance)(deregistered) )
 
 FC_REFLECT_DERIVED( graphene::chain::son_object, (graphene::db::object),
-                    (son_account)(vote_id)(total_votes)(url)(deposit)(signing_key)(pay_vb)(sidechain_public_keys) )
+                    (son_account)(vote_id)(total_votes)(url)(deposit)(signing_key)(pay_vb)(status)(sidechain_public_keys) )
 
 FC_REFLECT_DERIVED( graphene::chain::son_statistics_object,
                     (graphene::db::object),

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -156,6 +156,10 @@ struct proposal_operation_hardfork_visitor
       FC_ASSERT( block_time >= HARDFORK_SON_TIME, "son_report_down_operation not allowed yet!" );
    }
 
+   void operator()(const son_maintenance_operation &v) const {
+      FC_ASSERT( block_time >= HARDFORK_SON_TIME, "son_maintenance_operation not allowed yet!" );
+   }
+
    // loop and self visit in proposals
    void operator()(const proposal_create_operation &v) const {
       for (const op_wrapper &op : v.proposed_ops)

--- a/libraries/chain/son_evaluator.cpp
+++ b/libraries/chain/son_evaluator.cpp
@@ -175,4 +175,31 @@ object_id_type son_report_down_evaluator::do_apply(const son_report_down_operati
     return op.son_id;
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 
+void_result son_maintenance_evaluator::do_evaluate(const son_maintenance_operation& op)
+{ try {
+    FC_ASSERT(db().head_block_time() >= HARDFORK_SON_TIME, "Not allowed until SON HARDFORK"); // can be removed after HF date pass
+    FC_ASSERT(db().get(op.son_id).son_account == op.owner_account);
+    const auto& idx = db().get_index_type<son_index>().indices().get<by_id>();
+    auto itr = idx.find(op.son_id);
+    FC_ASSERT( itr != idx.end() );
+    // Inactive SONs can't go to maintenance
+    FC_ASSERT(itr->status == son_status::active || itr->status == son_status::in_maintenance, "Inactive SONs can't go to maintenance");
+    return void_result();
+} FC_CAPTURE_AND_RETHROW( (op) ) }
+
+object_id_type son_maintenance_evaluator::do_apply(const son_maintenance_operation& op)
+{ try {
+    const auto& idx = db().get_index_type<son_index>().indices().get<by_id>();
+    auto itr = idx.find(op.son_id);
+    if(itr != idx.end())
+    {
+        if(itr->status == son_status::active) {
+            db().modify(*itr, [](son_object &so) {
+                so.status = son_status::in_maintenance;
+            });
+        }
+    }
+    return op.son_id;
+} FC_CAPTURE_AND_RETHROW( (op) ) }
+
 } } // namespace graphene::chain

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1350,9 +1350,18 @@ class wallet_api
       signed_transaction delete_son(string owner_account,
                                     bool broadcast = false);
 
+      /** Modify status of the SON owned by the given account to maintenance.
+       *
+       * @param owner_account the name or id of the account which is owning the SON
+       * @param broadcast true to broadcast the transaction on the network
+       * @returns the signed transaction
+       */
+      signed_transaction start_son_maintenance(string owner_account,
+                                              bool broadcast = false);
+
       /** Modify status of the SON owned by the given account back to active.
        *
-       * @param owner_account the name or id of the account which is creating the witness
+       * @param owner_account the name or id of the account which is owning the SON
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction
        */

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1350,6 +1350,15 @@ class wallet_api
       signed_transaction delete_son(string owner_account,
                                     bool broadcast = false);
 
+      /** Modify status of the SON owned by the given account back to active.
+       *
+       * @param owner_account the name or id of the account which is creating the witness
+       * @param broadcast true to broadcast the transaction on the network
+       * @returns the signed transaction
+       */
+      signed_transaction stop_son_maintenance(string owner_account,
+                                              bool broadcast = false);
+
       /** Lists all SONs in the blockchain.
        * This returns a list of all account names that own SON, and the associated SON id,
        * sorted by name.  This lists SONs whether they are currently voted in or not.

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1939,6 +1939,25 @@ public:
       return sign_transaction( tx, broadcast );
    } FC_CAPTURE_AND_RETHROW( (owner_account)(broadcast) ) }
 
+   signed_transaction stop_son_maintenance(string owner_account,
+                                           bool broadcast)
+   { try {
+         son_object son = get_son(owner_account);
+
+         son_heartbeat_operation op;
+         op.owner_account = son.son_account;
+         op.son_id = son.id;
+         op.ts = _remote_db->get_dynamic_global_properties().time; // or fc::time_point_sec(fc::time_point::now()) ???
+
+         signed_transaction tx;
+         tx.operations.push_back( op );
+         set_operation_fees( tx, _remote_db->get_global_properties().parameters.current_fees );
+         tx.validate();
+
+         return sign_transaction( tx, broadcast );
+   } FC_CAPTURE_AND_RETHROW( (owner_account) ) }
+
+
    map<string, son_id_type> list_active_sons()
    { try {
       global_property_object gpo = get_global_properties();
@@ -4401,6 +4420,11 @@ signed_transaction wallet_api::delete_son(string owner_account,
                                           bool broadcast /* = false */)
 {
    return my->delete_son(owner_account, broadcast);
+}
+
+signed_transaction wallet_api::stop_son_maintenance(string owner_account, bool broadcast)
+{
+   return my->stop_son_maintenance(owner_account, broadcast);
 }
 
 map<string, son_id_type> wallet_api::list_sons(const string& lowerbound, uint32_t limit)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1939,6 +1939,23 @@ public:
       return sign_transaction( tx, broadcast );
    } FC_CAPTURE_AND_RETHROW( (owner_account)(broadcast) ) }
 
+   signed_transaction start_son_maintenance(string owner_account,
+                                           bool broadcast)
+   { try {
+         son_object son = get_son(owner_account);
+
+         son_maintenance_operation op;
+         op.owner_account = son.son_account;
+         op.son_id = son.id;
+
+         signed_transaction tx;
+         tx.operations.push_back( op );
+         set_operation_fees( tx, _remote_db->get_global_properties().parameters.current_fees );
+         tx.validate();
+
+         return sign_transaction( tx, broadcast );
+   } FC_CAPTURE_AND_RETHROW( (owner_account) ) }
+
    signed_transaction stop_son_maintenance(string owner_account,
                                            bool broadcast)
    { try {
@@ -1956,7 +1973,6 @@ public:
 
          return sign_transaction( tx, broadcast );
    } FC_CAPTURE_AND_RETHROW( (owner_account) ) }
-
 
    map<string, son_id_type> list_active_sons()
    { try {
@@ -4420,6 +4436,11 @@ signed_transaction wallet_api::delete_son(string owner_account,
                                           bool broadcast /* = false */)
 {
    return my->delete_son(owner_account, broadcast);
+}
+
+signed_transaction wallet_api::start_son_maintenance(string owner_account, bool broadcast)
+{
+   return my->start_son_maintenance(owner_account, broadcast);
 }
 
 signed_transaction wallet_api::stop_son_maintenance(string owner_account, bool broadcast)


### PR DESCRIPTION
Also fixes a bug with going SON to active mode. Adds `start_son_maintenance` and `stop_son_maintenance` calls to CLI wallet and tests for this functions. 