### PR TITLE
resync/replay issues addressed

### DIFF
--- a/libraries/chain/hardfork.d/GPOS.hf
+++ b/libraries/chain/hardfork.d/GPOS.hf
@@ -1,4 +1,4 @@
-// GPOS HARDFORK Monday, 6 January 2020 01:00:00 GMT
+// GPOS HARDFORK Monday, 17 February 2020 22:00:00 GMT
 #ifndef HARDFORK_GPOS_TIME
-#define HARDFORK_GPOS_TIME (fc::time_point_sec( 1578272400 ))
+#define HARDFORK_GPOS_TIME (fc::time_point_sec( 1581976800 ))
 #endif

--- a/libraries/chain/include/graphene/chain/protocol/chain_parameters.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/chain_parameters.hpp
@@ -35,12 +35,11 @@ namespace graphene { namespace chain { struct fee_schedule; } }
 namespace graphene { namespace chain {
    struct parameter_extension
    {
-      optional< bet_multiplier_type > min_bet_multiplier                = GRAPHENE_DEFAULT_MIN_BET_MULTIPLIER;
-      optional< bet_multiplier_type > max_bet_multiplier                = GRAPHENE_DEFAULT_MAX_BET_MULTIPLIER;
-      optional< uint16_t >            betting_rake_fee_percentage       = GRAPHENE_DEFAULT_RAKE_FEE_PERCENTAGE;
-      optional< flat_map<bet_multiplier_type, bet_multiplier_type> > 
-      permitted_betting_odds_increments                                 = flat_map<bet_multiplier_type, bet_multiplier_type>(GRAPHENE_DEFAULT_PERMITTED_BETTING_ODDS_INCREMENTS);
-      optional< uint16_t >            live_betting_delay_time           = GRAPHENE_DEFAULT_LIVE_BETTING_DELAY_TIME;
+      optional< bet_multiplier_type > min_bet_multiplier;
+      optional< bet_multiplier_type > max_bet_multiplier;
+      optional< uint16_t >            betting_rake_fee_percentage;
+      optional< flat_map<bet_multiplier_type, bet_multiplier_type> > permitted_betting_odds_increments;
+      optional< uint16_t >            live_betting_delay_time;
       optional< uint16_t >            sweeps_distribution_percentage    = SWEEPS_DEFAULT_DISTRIBUTION_PERCENTAGE;
       optional< asset_id_type >       sweeps_distribution_asset         = SWEEPS_DEFAULT_DISTRIBUTION_ASSET;
       optional< account_id_type >     sweeps_vesting_accumulator_account= SWEEPS_ACCUMULATOR_ACCOUNT;
@@ -148,6 +147,7 @@ FC_REFLECT( graphene::chain::parameter_extension,
    (min_bet_multiplier)
    (max_bet_multiplier)
    (betting_rake_fee_percentage)
+   (permitted_betting_odds_increments)
    (live_betting_delay_time)
    (sweeps_distribution_percentage)
    (sweeps_distribution_asset)

--- a/libraries/plugins/bookie/bookie_plugin.cpp
+++ b/libraries/plugins/bookie/bookie_plugin.cpp
@@ -370,8 +370,8 @@ void bookie_plugin_impl::on_block_applied( const signed_block& )
          assert(bet_iter != persistent_bets_by_bet_id.end());
          if (bet_iter != persistent_bets_by_bet_id.end())
          {
-            ilog("Adding bet_canceled_operation ${canceled_id} to bet ${bet_id}'s associated operations", 
-                 ("canceled_id", op.id)("bet_id", bet_canceled_op.bet_id));
+            //ilog("Adding bet_canceled_operation ${canceled_id} to bet ${bet_id}'s associated operations", 
+            //     ("canceled_id", op.id)("bet_id", bet_canceled_op.bet_id));
             if (is_operation_history_object_stored(op.id))
                db.modify(*bet_iter, [&]( persistent_bet_object& obj ) {
                   obj.associated_operations.emplace_back(op.id);
@@ -386,8 +386,8 @@ void bookie_plugin_impl::on_block_applied( const signed_block& )
          assert(bet_iter != persistent_bets_by_bet_id.end());
          if (bet_iter != persistent_bets_by_bet_id.end())
          {
-            ilog("Adding bet_adjusted_operation ${adjusted_id} to bet ${bet_id}'s associated operations", 
-                 ("adjusted_id", op.id)("bet_id", bet_adjusted_op.bet_id));
+            //ilog("Adding bet_adjusted_operation ${adjusted_id} to bet ${bet_id}'s associated operations", 
+            //     ("adjusted_id", op.id)("bet_id", bet_adjusted_op.bet_id));
             if (is_operation_history_object_stored(op.id))
                db.modify(*bet_iter, [&]( persistent_bet_object& obj ) {
                   obj.associated_operations.emplace_back(op.id);

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2122,6 +2122,7 @@ public:
 
       asset_object asset_obj = get_asset( asset_symbol );
       vector< vesting_balance_object > vbos;
+       vesting_balance_object vbo;
       fc::optional<vesting_balance_id_type> vbid = maybe_id<vesting_balance_id_type>(account_name);
       if( !vbid )
       {
@@ -2134,7 +2135,13 @@ public:
       if(!vbos.size())
          vbos.emplace_back( get_object<vesting_balance_object>(*vbid) );
  
-      const vesting_balance_object& vbo = vbos.front();
+      for (const vesting_balance_object& vesting_balance_obj: vbos) {
+         if(vesting_balance_obj.balance_type == vesting_balance_type::gpos)
+         {
+            vbo = vesting_balance_obj;
+            break;
+         }
+      }
 
       vesting_balance_withdraw_operation vesting_balance_withdraw_op;
 


### PR DESCRIPTION
Few resync/replay issues addressed with this PR.
live_betting_delay_time is updated to 0 secs on mainnet and with recent changes 5 secs will be default(changes done to show all extension parameters of global object) and causing bet_adjustment issues during resync. Also observed behaviour of GPOS with zero votes from all account holders after crossing 1st sub-period.
At present, GPOS hardfork date has been updated to 17th Feb 2020 at 22:00:00 GMT
