### PR TITLE
Enable mandatory plugins to have smooth transition for next release

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -981,18 +981,21 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
       std::exit(EXIT_SUCCESS);
    }
 
-   std::vector<string> wanted;
+   std::set<string> wanted;
    if( options.count("plugins") )
    {
       boost::split(wanted, options.at("plugins").as<std::string>(), [](char c){return c == ' ';});
    }
    else
-   {
-      wanted.push_back("witness");
-      wanted.push_back("account_history");
-      wanted.push_back("market_history");
-      wanted.push_back("bookie");
+   {      
+      wanted.insert("account_history");
+      wanted.insert("market_history");
+      wanted.insert("accounts_list");
+      wanted.insert("affiliate_stats");
    }
+   wanted.insert("witness");
+   wanted.insert("bookie");
+
    int es_ah_conflict_counter = 0;
    for (auto& it : wanted)
    {

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -28,8 +28,12 @@
 
 #include <graphene/utilities/tempdir.hpp>
 
+#include <graphene/witness/witness.hpp>
 #include <graphene/account_history/account_history_plugin.hpp>
-
+#include <graphene/bookie/bookie_plugin.hpp>
+#include <graphene/accounts_list/accounts_list_plugin.hpp>
+#include <graphene/affiliate_stats/affiliate_stats_plugin.hpp>
+#include <graphene/market_history/market_history_plugin.hpp>
 #include <fc/thread/thread.hpp>
 #include <fc/smart_ref_impl.hpp>
 
@@ -56,10 +60,15 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       BOOST_TEST_MESSAGE( "Creating and initializing app1" );
 
       graphene::app::application app1;
+      app1.register_plugin<graphene::witness_plugin::witness_plugin>();
       app1.register_plugin<graphene::account_history::account_history_plugin>();
+      app1.register_plugin<graphene::bookie::bookie_plugin>();
+      app1.register_plugin<graphene::accounts_list::accounts_list_plugin>();
+      app1.register_plugin<graphene::affiliate_stats::affiliate_stats_plugin>();
+      app1.register_plugin<graphene::market_history::market_history_plugin>();
+
       boost::program_options::variables_map cfg;
       cfg.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:0"), false));
-      cfg.emplace("plugins", boost::program_options::variable_value(string(" "), false));
       app1.initialize(app_dir.path(), cfg);
       cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
 
@@ -72,7 +81,12 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       auto cfg2 = cfg;
 
       graphene::app::application app2;
-      app2.register_plugin<account_history::account_history_plugin>();
+      app2.register_plugin<graphene::witness_plugin::witness_plugin>();
+      app2.register_plugin<graphene::account_history::account_history_plugin>();
+      app2.register_plugin<graphene::bookie::bookie_plugin>();
+      app2.register_plugin<graphene::accounts_list::accounts_list_plugin>();
+      app2.register_plugin<graphene::affiliate_stats::affiliate_stats_plugin>();
+      app2.register_plugin<graphene::market_history::market_history_plugin>();
       cfg2.erase("p2p-endpoint");
       cfg2.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:0"), false));
       cfg2.emplace("seed-node", boost::program_options::variable_value(vector<string>{endpoint1}, false));

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -30,6 +30,8 @@
 #include <graphene/account_history/account_history_plugin.hpp>
 #include <graphene/witness/witness.hpp>
 #include <graphene/market_history/market_history_plugin.hpp>
+#include <graphene/accounts_list/accounts_list_plugin.hpp>
+#include <graphene/affiliate_stats/affiliate_stats_plugin.hpp>
 
 #include <graphene/egenesis/egenesis.hpp>
 #include <graphene/wallet/wallet.hpp>
@@ -125,9 +127,11 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
    std::shared_ptr<graphene::app::application> app1(new graphene::app::application{});
 
    app1->register_plugin< graphene::bookie::bookie_plugin>();
-   app1->register_plugin<graphene::account_history::account_history_plugin>();
+   app1->register_plugin< graphene::account_history::account_history_plugin>();
    app1->register_plugin< graphene::market_history::market_history_plugin >();
    app1->register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1->register_plugin< graphene::accounts_list::accounts_list_plugin >();
+   app1->register_plugin< graphene::affiliate_stats::affiliate_stats_plugin >();
    app1->startup_plugins();
    boost::program_options::variables_map cfg;
 #ifdef _WIN32


### PR DESCRIPTION
On bringing new elasticsearch plugin changes, witness should be able to run default plugins without plugin options. At the same time, witness should run other mandatory plugins like "witness" if only "elasticsearch" and "es-objects" passes under plugin options.
       Changes done to implement the above changes.
Note: we can't enable both account_history and elasticsearch plugins at the same time