### PR TITLE
Add SON statistic for tracking reported sidechain transactions

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/son_wallet_deposit.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/son_wallet_deposit.hpp
@@ -12,6 +12,7 @@ namespace graphene { namespace chain {
         asset fee;
         account_id_type payer;
 
+        son_id_type son_id;
         fc::time_point_sec timestamp;
         peerplays_sidechain::sidechain_type sidechain;
         std::string sidechain_uid;
@@ -45,7 +46,7 @@ namespace graphene { namespace chain {
 
 FC_REFLECT(graphene::chain::son_wallet_deposit_create_operation::fee_parameters_type, (fee) )
 FC_REFLECT(graphene::chain::son_wallet_deposit_create_operation, (fee)(payer)
-      (timestamp) (sidechain) (sidechain_uid) (sidechain_transaction_id) (sidechain_from) (sidechain_to) (sidechain_currency) (sidechain_amount) (peerplays_from) (peerplays_to) (peerplays_asset))
+      (son_id) (timestamp) (sidechain) (sidechain_uid) (sidechain_transaction_id) (sidechain_from) (sidechain_to) (sidechain_currency) (sidechain_amount) (peerplays_from) (peerplays_to) (peerplays_asset))
 FC_REFLECT(graphene::chain::son_wallet_deposit_process_operation::fee_parameters_type, (fee) )
 FC_REFLECT(graphene::chain::son_wallet_deposit_process_operation, (fee)(payer)
       (son_wallet_deposit_id))

--- a/libraries/chain/include/graphene/chain/protocol/son_wallet_withdraw.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/son_wallet_withdraw.hpp
@@ -12,6 +12,7 @@ namespace graphene { namespace chain {
         asset fee;
         account_id_type payer;
 
+        son_id_type son_id;
         fc::time_point_sec timestamp;
         peerplays_sidechain::sidechain_type sidechain;
         std::string peerplays_uid;
@@ -44,7 +45,7 @@ namespace graphene { namespace chain {
 
 FC_REFLECT(graphene::chain::son_wallet_withdraw_create_operation::fee_parameters_type, (fee) )
 FC_REFLECT(graphene::chain::son_wallet_withdraw_create_operation, (fee)(payer)
-      (timestamp) (sidechain) (peerplays_uid) (peerplays_transaction_id) (peerplays_from) (peerplays_asset) (withdraw_sidechain) (withdraw_address) (withdraw_currency) (withdraw_amount) )
+      (son_id) (timestamp) (sidechain) (peerplays_uid) (peerplays_transaction_id) (peerplays_from) (peerplays_asset) (withdraw_sidechain) (withdraw_address) (withdraw_currency) (withdraw_amount) )
 FC_REFLECT(graphene::chain::son_wallet_withdraw_process_operation::fee_parameters_type, (fee) )
 FC_REFLECT(graphene::chain::son_wallet_withdraw_process_operation, (fee)(payer)
       (son_wallet_withdraw_id))

--- a/libraries/chain/include/graphene/chain/son_object.hpp
+++ b/libraries/chain/include/graphene/chain/son_object.hpp
@@ -42,6 +42,10 @@ namespace graphene { namespace chain {
          fc::time_point_sec last_down_timestamp;
          // Last Active heartbeat timestamp
          fc::time_point_sec last_active_timestamp;
+         // Total sidechain transactions reported by SON network while SON was active
+         uint64_t total_sidechain_txs_reported = 0;
+         // Sidechain transactions reported by this SON
+         uint64_t sidechain_txs_reported = 0;
    };
 
    /**
@@ -87,14 +91,20 @@ namespace graphene { namespace chain {
    >;
    using son_index = generic_index<son_object, son_multi_index_type>;
 
+   struct by_owner;
    using son_stats_multi_index_type = multi_index_container<
       son_statistics_object,
       indexed_by<
-         ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >
+         ordered_unique< tag<by_id>,
+            member<object, object_id_type, &object::id>
+         >,
+         ordered_unique< tag<by_owner>,
+            member<son_statistics_object, son_id_type, &son_statistics_object::owner>
+         >
       >
    >;
-
    using son_stats_index = generic_index<son_statistics_object, son_stats_multi_index_type>;
+
 } } // graphene::chain
 
 FC_REFLECT_ENUM(graphene::chain::son_status, (inactive)(active)(request_maintenance)(in_maintenance)(deregistered) )
@@ -111,4 +121,6 @@ FC_REFLECT_DERIVED( graphene::chain::son_statistics_object,
                     (current_interval_downtime)
                     (last_down_timestamp)
                     (last_active_timestamp)
+                    (total_sidechain_txs_reported)
+                    (sidechain_txs_reported)
                   )

--- a/libraries/chain/include/graphene/chain/son_wallet_deposit_object.hpp
+++ b/libraries/chain/include/graphene/chain/son_wallet_deposit_object.hpp
@@ -18,7 +18,6 @@ namespace graphene { namespace chain {
 
          time_point_sec timestamp;
          peerplays_sidechain::sidechain_type sidechain;
-         int64_t confirmations;
          std::string sidechain_uid;
          std::string sidechain_transaction_id;
          std::string sidechain_from;
@@ -28,6 +27,9 @@ namespace graphene { namespace chain {
          chain::account_id_type peerplays_from;
          chain::account_id_type peerplays_to;
          chain::asset peerplays_asset;
+
+         std::set<son_id_type> expected_reports;
+         std::set<son_id_type> received_reports;
 
          bool processed;
    };
@@ -63,7 +65,8 @@ namespace graphene { namespace chain {
 } } // graphene::chain
 
 FC_REFLECT_DERIVED( graphene::chain::son_wallet_deposit_object, (graphene::db::object),
-                    (timestamp) (sidechain) (confirmations)
+                    (timestamp) (sidechain)
                     (sidechain_uid) (sidechain_transaction_id) (sidechain_from) (sidechain_to) (sidechain_currency) (sidechain_amount)
                     (peerplays_from) (peerplays_to) (peerplays_asset)
+                    (expected_reports) (received_reports)
                     (processed) )

--- a/libraries/chain/include/graphene/chain/son_wallet_withdraw_object.hpp
+++ b/libraries/chain/include/graphene/chain/son_wallet_withdraw_object.hpp
@@ -18,7 +18,6 @@ namespace graphene { namespace chain {
 
          time_point_sec timestamp;
          peerplays_sidechain::sidechain_type sidechain;
-         int64_t confirmations;
          std::string peerplays_uid;
          std::string peerplays_transaction_id;
          chain::account_id_type peerplays_from;
@@ -27,6 +26,10 @@ namespace graphene { namespace chain {
          std::string withdraw_address;
          std::string withdraw_currency;
          safe<int64_t> withdraw_amount;
+
+         std::set<son_id_type> expected_reports;
+         std::set<son_id_type> received_reports;
+
          bool processed;
    };
 
@@ -61,7 +64,8 @@ namespace graphene { namespace chain {
 } } // graphene::chain
 
 FC_REFLECT_DERIVED( graphene::chain::son_wallet_withdraw_object, (graphene::db::object),
-                    (timestamp) (sidechain) (confirmations)
+                    (timestamp) (sidechain)
                     (peerplays_uid) (peerplays_transaction_id) (peerplays_from) (peerplays_asset)
                     (withdraw_sidechain) (withdraw_address) (withdraw_currency) (withdraw_amount)
+                    (expected_reports) (received_reports)
                     (processed) )

--- a/libraries/chain/son_wallet_deposit_evaluator.cpp
+++ b/libraries/chain/son_wallet_deposit_evaluator.cpp
@@ -2,6 +2,7 @@
 
 #include <graphene/chain/database.hpp>
 #include <graphene/chain/is_authorized_asset.hpp>
+#include <graphene/chain/son_object.hpp>
 #include <graphene/chain/son_wallet_deposit_object.hpp>
 
 namespace graphene { namespace chain {
@@ -11,8 +12,9 @@ void_result create_son_wallet_deposit_evaluator::do_evaluate(const son_wallet_de
    FC_ASSERT(db().head_block_time() >= HARDFORK_SON_TIME, "Not allowed until SON HARDFORK");
    FC_ASSERT( op.payer == GRAPHENE_SON_ACCOUNT, "SON paying account must be set as payer." );
 
-   //const auto& idx = db().get_index_type<son_wallet_deposit_index>().indices().get<by_sidechain_uid>();
-   //FC_ASSERT(idx.find(op.sidechain_uid) == idx.end(), "Already registered " + op.sidechain_uid);
+   const auto &idx = db().get_index_type<son_stats_index>().indices().get<by_owner>();
+   FC_ASSERT(idx.find(op.son_id) != idx.end(), "Statistic object for a given SON ID does not exists");
+
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 
@@ -24,7 +26,6 @@ object_id_type create_son_wallet_deposit_evaluator::do_apply(const son_wallet_de
       const auto& new_son_wallet_deposit_object = db().create<son_wallet_deposit_object>( [&]( son_wallet_deposit_object& swto ){
          swto.timestamp = op.timestamp;
          swto.sidechain = op.sidechain;
-         swto.confirmations = 1;
          swto.sidechain_uid = op.sidechain_uid;
          swto.sidechain_transaction_id = op.sidechain_transaction_id;
          swto.sidechain_from = op.sidechain_from;
@@ -33,12 +34,32 @@ object_id_type create_son_wallet_deposit_evaluator::do_apply(const son_wallet_de
          swto.peerplays_from = op.peerplays_from;
          swto.peerplays_to = op.peerplays_to;
          swto.peerplays_asset = op.peerplays_asset;
+
+         auto &gpo = db().get_global_properties();
+         for (auto &si : gpo.active_sons) {
+            swto.expected_reports.insert(si.son_id);
+
+            auto stats_itr = db().get_index_type<son_stats_index>().indices().get<by_owner>().find(si.son_id);
+            db().modify(*stats_itr, [&op, &si](son_statistics_object &sso) {
+               sso.total_sidechain_txs_reported = sso.total_sidechain_txs_reported + 1;
+               if (si.son_id == op.son_id) {
+                  sso.sidechain_txs_reported = sso.sidechain_txs_reported + 1;
+               }
+            });
+         }
+
+         swto.received_reports.insert(op.son_id);
+
          swto.processed = false;
       });
       return new_son_wallet_deposit_object.id;
    } else {
       db().modify(*itr, [&op](son_wallet_deposit_object &swto) {
-         swto.confirmations = swto.confirmations + 1;
+         swto.received_reports.insert(op.son_id);
+      });
+      auto stats_itr = db().get_index_type<son_stats_index>().indices().get<by_owner>().find(op.son_id);
+      db().modify(*stats_itr, [&op](son_statistics_object &sso) {
+         sso.sidechain_txs_reported = sso.sidechain_txs_reported + 1;
       });
       return (*itr).id;
    }
@@ -51,7 +72,7 @@ void_result process_son_wallet_deposit_evaluator::do_evaluate(const son_wallet_d
 
    const auto& idx = db().get_index_type<son_wallet_deposit_index>().indices().get<by_id>();
    const auto& itr = idx.find(op.son_wallet_deposit_id);
-   FC_ASSERT(itr != idx.end(), "Son wallet transfer not found");
+   FC_ASSERT(itr != idx.end(), "Son wallet deposit not found");
 
    const database& d = db();
 

--- a/libraries/plugins/peerplays_sidechain/sidechain_net_handler.cpp
+++ b/libraries/plugins/peerplays_sidechain/sidechain_net_handler.cpp
@@ -74,6 +74,7 @@ void sidechain_net_handler::sidechain_event_data_received(const sidechain_event_
    if ((sed.peerplays_to == GRAPHENE_SON_ACCOUNT) && (sed.sidechain_currency.compare("1.3.0") != 0)) {
       son_wallet_deposit_create_operation op;
       op.payer = GRAPHENE_SON_ACCOUNT;
+      //op.son_id = ; // to be filled for each son
       op.timestamp = sed.timestamp;
       op.sidechain = sed.sidechain;
       op.sidechain_uid = sed.sidechain_uid;
@@ -88,6 +89,9 @@ void sidechain_net_handler::sidechain_event_data_received(const sidechain_event_
 
       for (son_id_type son_id : plugin.get_sons()) {
          if (plugin.is_active_son(son_id)) {
+
+            op.son_id = son_id;
+
             proposal_create_operation proposal_op;
             proposal_op.fee_paying_account = plugin.get_son_object(son_id).son_account;
             proposal_op.proposed_ops.emplace_back(op_wrapper(op));
@@ -117,6 +121,7 @@ void sidechain_net_handler::sidechain_event_data_received(const sidechain_event_
 
       son_wallet_withdraw_create_operation op;
       op.payer = GRAPHENE_SON_ACCOUNT;
+      //op.son_id = ; // to be filled for each son
       op.timestamp = sed.timestamp;
       op.sidechain = sed.sidechain;
       op.peerplays_uid = sed.sidechain_uid;
@@ -130,6 +135,9 @@ void sidechain_net_handler::sidechain_event_data_received(const sidechain_event_
 
       for (son_id_type son_id : plugin.get_sons()) {
          if (plugin.is_active_son(son_id)) {
+
+            op.son_id = son_id;
+
             proposal_create_operation proposal_op;
             proposal_op.fee_paying_account = plugin.get_son_object(son_id).son_account;
             proposal_op.proposed_ops.emplace_back(op_wrapper(op));

--- a/libraries/plugins/peerplays_sidechain/sidechain_net_handler_bitcoin.cpp
+++ b/libraries/plugins/peerplays_sidechain/sidechain_net_handler_bitcoin.cpp
@@ -549,7 +549,7 @@ void zmq_listener::handle_zmq() {
          const auto header = std::string(static_cast<char *>(msg[0].data()), msg[0].size());
          const auto block_hash = boost::algorithm::hex(std::string(static_cast<char *>(msg[1].data()), msg[1].size()));
          event_received(block_hash);
-      } catch (zmq::error_t& e) {
+      } catch (zmq::error_t &e) {
       }
    }
 }


### PR DESCRIPTION
- Deposit and Withdrawal object extended to contain expected
  and received transaction reports from SON network
- SON statistic object extended to contain total number of
  sidechain transactions reported by SON network when SON was
  active and number of transactions reported by single SON when
  he was active
- Code formatting