### PR TITLE
[SON-311] Son creation with cli wallet refactoring

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1322,6 +1322,25 @@ class wallet_api
                                     flat_map<peerplays_sidechain::sidechain_type, string> sidechain_public_keys,
                                     bool broadcast = false);
 
+      /** Creates a SON object owned by the given account.
+       *
+       * Tries to create a SON object owned by the given account using
+       * existing vesting balances, fails if can't quess matching
+       * vesting balance objects. If several vesting balance objects matches
+       * this function uses the recent one.
+       *
+       * @param owner_account the name or id of the account which is creating the SON
+       * @param url a URL to include in the SON record in the blockchain.  Clients may
+       *            display this when showing a list of SONs.  May be blank.
+       * @param sidechain_public_keys The new set of sidechain public keys.
+       * @param broadcast true to broadcast the transaction on the network
+       * @returns the signed transaction registering a SON
+       */
+      signed_transaction try_create_son(string owner_account,
+                                    string url,
+                                    flat_map<peerplays_sidechain::sidechain_type, string> sidechain_public_keys,
+                                    bool broadcast = false);
+
       /**
        * Update a SON object owned by the given account.
        *
@@ -2232,6 +2251,7 @@ FC_API( graphene::wallet::wallet_api,
         (list_witnesses)
         (list_committee_members)
         (create_son)
+        (try_create_son)
         (update_son)
         (delete_son)
         (list_sons)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -4410,6 +4410,37 @@ signed_transaction wallet_api::create_son(string owner_account,
    return my->create_son(owner_account, url, deposit_id, pay_vb_id, sidechain_public_keys, broadcast);
 }
 
+signed_transaction wallet_api::try_create_son(string owner_account,
+                              string url,
+                              flat_map<peerplays_sidechain::sidechain_type, string> sidechain_public_keys,
+                              bool broadcast /* = false */)
+{
+   vesting_balance_id_type deposit_id;
+   bool deposit_found = false;
+   vesting_balance_id_type pay_vb_id;
+   bool pay_vb_found = false;
+   vector<vesting_balance_object_with_info> vbs = get_vesting_balances(owner_account);
+   for(const auto& vb: vbs)
+   {
+      if ((vb.balance_type == vesting_balance_type::son) &&
+          (vb.get_asset_amount() >= my->get_global_properties().parameters.son_vesting_amount()) &&
+          (vb.policy.which() == vesting_policy::tag<dormant_vesting_policy>::value))
+      {
+         deposit_found = true;
+         deposit_id = vb.id;
+      }
+      if ((vb.balance_type == vesting_balance_type::normal) &&
+          (vb.policy.which() == vesting_policy::tag<linear_vesting_policy>::value))
+      {
+         pay_vb_found = true;
+         pay_vb_id = vb.id;
+      }
+   }
+   if (!deposit_found || !pay_vb_found)
+      FC_THROW("Failed to find vesting balance objects");
+   return my->create_son(owner_account, url, deposit_id, pay_vb_id, sidechain_public_keys, broadcast);
+}
+
 signed_transaction wallet_api::update_son(string owner_account,
                                           string url,
                                           string block_signing_key,


### PR DESCRIPTION
Adds new `try_create_son` call to `wallet_api` that doesn't require explicit vesting balance object params