### PR TITLE
[SON-333] libbitcoin integration

### DIFF
--- a/libraries/plugins/CMakeLists.txt
+++ b/libraries/plugins/CMakeLists.txt
@@ -12,3 +12,5 @@ add_subdirectory( debug_witness )
 add_subdirectory( snapshot )
 add_subdirectory( peerplays_sidechain )
 add_subdirectory( es_objects )
+
+add_subdirectory( libbitcoin )

--- a/libraries/plugins/libbitcoin/CMakeLists.txt
+++ b/libraries/plugins/libbitcoin/CMakeLists.txt
@@ -2,25 +2,28 @@ include(ExternalProject)
 
 set(LIBBITCOIN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libbitcoin-system)
 set(LIBBITCOIN_BIN ${CMAKE_CURRENT_BINARY_DIR}/libbitcoin)
-set(LIBBITCOIN_STATIC_LIB ${LIBBITCOIN_BIN}/lib/libbitcoin.a)
-set(LIBBITCOIN_INCLUDES ${LIBBITCOIN_BIN}/include)
+set(LIBBITCOIN_STATIC_LIB ${LIBBITCOIN_BIN}/lib/libbitcoin-system.a)
+set(LIBBITCOIN_INCLUDES ${LIBBITCOIN_DIR}/include)
 
 file(MAKE_DIRECTORY ${LIBBITCOIN_INCLUDES})
 
 ExternalProject_Add(
-    libbitcoin
+    bitcoinsystem
     PREFIX ${LIBBITCOIN_BIN}
     SOURCE_DIR ${LIBBITCOIN_DIR}
     DOWNLOAD_COMMAND  cd ${LIBBITCOIN_DIR} && ${LIBBITCOIN_DIR}/autogen.sh
     CONFIGURE_COMMAND ${LIBBITCOIN_DIR}/configure --srcdir=${LIBBITCOIN_DIR} --prefix=${LIBBITCOIN_BIN} --enable-static=yes --disable-shared --with-examples=no
-    BUILD_COMMAND make
+    BUILD_COMMAND make -j4
     INSTALL_COMMAND make install
     BUILD_BYPRODUCTS ${LIBBITCOIN_STATIC_LIB}
 )
 
-add_library(bitcoin STATIC IMPORTED GLOBAL)
+add_library(libbitcoin STATIC IMPORTED GLOBAL)
 
-add_dependencies(bitcoin libbitcoin)
+set_target_properties(bitcoinsystem PROPERTIES IMPORTED_LOCATION ${LIBBITCOIN_STATIC_LIB})
+set_target_properties(bitcoinsystem PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBBITCOIN_INCLUDES})
 
-set_target_properties(bitcoin PROPERTIES IMPORTED_LOCATION ${LIBBITCOIN_STATIC_LIB})
-set_target_properties(bitcoin PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBBITCOIN_INCLUDES})
+add_dependencies(libbitcoin bitcoinsystem)
+
+set_target_properties(libbitcoin PROPERTIES IMPORTED_LOCATION ${LIBBITCOIN_STATIC_LIB})
+set_target_properties(libbitcoin PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBBITCOIN_INCLUDES})

--- a/libraries/plugins/libbitcoin/CMakeLists.txt
+++ b/libraries/plugins/libbitcoin/CMakeLists.txt
@@ -1,0 +1,26 @@
+include(ExternalProject)
+
+set(LIBBITCOIN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libbitcoin-system)
+set(LIBBITCOIN_BIN ${CMAKE_CURRENT_BINARY_DIR}/libbitcoin)
+set(LIBBITCOIN_STATIC_LIB ${LIBBITCOIN_BIN}/lib/libbitcoin.a)
+set(LIBBITCOIN_INCLUDES ${LIBBITCOIN_BIN}/include)
+
+file(MAKE_DIRECTORY ${LIBBITCOIN_INCLUDES})
+
+ExternalProject_Add(
+    libbitcoin
+    PREFIX ${LIBBITCOIN_BIN}
+    SOURCE_DIR ${LIBBITCOIN_DIR}
+    DOWNLOAD_COMMAND  cd ${LIBBITCOIN_DIR} && ${LIBBITCOIN_DIR}/autogen.sh
+    CONFIGURE_COMMAND ${LIBBITCOIN_DIR}/configure --srcdir=${LIBBITCOIN_DIR} --prefix=${LIBBITCOIN_BIN} --enable-static=yes --disable-shared --with-examples=no
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+    BUILD_BYPRODUCTS ${LIBBITCOIN_STATIC_LIB}
+)
+
+add_library(bitcoin STATIC IMPORTED GLOBAL)
+
+add_dependencies(bitcoin libbitcoin)
+
+set_target_properties(bitcoin PROPERTIES IMPORTED_LOCATION ${LIBBITCOIN_STATIC_LIB})
+set_target_properties(bitcoin PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBBITCOIN_INCLUDES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,3 +60,5 @@ add_executable( es_test ${ES_SOURCES} ${COMMON_SOURCES} )
 target_link_libraries( es_test graphene_chain graphene_app graphene_account_history graphene_elasticsearch graphene_es_objects graphene_egenesis_none fc ${PLATFORM_SPECIFIC_LIBS} )
 
 add_subdirectory( generate_empty_blocks )
+
+add_subdirectory( bitcoin_test )

--- a/tests/bitcoin_test/CMakeLists.txt
+++ b/tests/bitcoin_test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable( bitcoin_test main.cpp )
+target_link_libraries( bitcoin_test
+                       PRIVATE bitcoin fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/tests/bitcoin_test/CMakeLists.txt
+++ b/tests/bitcoin_test/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable( bitcoin_test main.cpp )
 target_link_libraries( bitcoin_test
-                       PRIVATE bitcoin fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+                       PRIVATE libbitcoin ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/tests/bitcoin_test/main.cpp
+++ b/tests/bitcoin_test/main.cpp
@@ -1,0 +1,6 @@
+#include <bitcoin/system.hpp>
+
+int main()
+{
+   return 0;
+}


### PR DESCRIPTION
Add to cmake ability to build pre-downloaded libbitcoin-system (in libraries/plugin/libbitcoin folder). Later libbitcoin can be added as git submodule.