### PR TITLE
GPOS2 HF - Handle rolling period on missing blocks

### DIFF
--- a/libraries/chain/hardfork.d/GPOS2.hf
+++ b/libraries/chain/hardfork.d/GPOS2.hf
@@ -1,0 +1,4 @@
+// GPOS2 HARDFORK Tuesday, 28 July 2020 01:00:00 GMT
+#ifndef HARDFORK_GPOS2_TIME
+#define HARDFORK_GPOS2_TIME (fc::time_point_sec( 1595898000 ))
+#endif


### PR DESCRIPTION
- Rolling period not aligning with maintenance block if there are missing blocks at GPOS period end.
- HF epoch time to be adjusted separately for testnet and master branches.
- This should fix assert failures happening during maintenance.